### PR TITLE
Added binding support for parenthesized expressions

### DIFF
--- a/mc/CodeAnalysis/Binding/Binder.cs
+++ b/mc/CodeAnalysis/Binding/Binder.cs
@@ -20,6 +20,8 @@ namespace Minsk.CodeAnalysis.Binding
                     return BindUnaryExpression((UnaryExpressionSyntax)syntax);
                 case SyntaxKind.BinaryExpression:
                     return BindBinaryExpression((BinaryExpressionSyntax)syntax);
+               case SyntaxKind.ParenthesizedExpression:
+                    return BindExpression(((ParenthesizedExpressionSyntax)syntax).Expression);
                 default:
                     throw new Exception($"Unexpected syntax {syntax.Kind}");
             }

--- a/mc/Program.cs
+++ b/mc/Program.cs
@@ -81,7 +81,7 @@ namespace Minsk
 
             Console.WriteLine();
             
-            indent += isLast ? "   " : "│   ";
+            indent += isLast ? "   " : "│  ";
 
             var lastChild = node.GetChildren().LastOrDefault();
 


### PR DESCRIPTION
It was failing in runtime for expressions of the kind "(1 + 2) * 3"