### PR TITLE
Fix build badge to only show master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minsk
 
-[![Build Status](https://terrajobst.visualstudio.com/Minsk/_apis/build/status/terrajobst.minsk)](https://terrajobst.visualstudio.com/Minsk/_build/latest?definitionId=13)
+[![Build Status](https://terrajobst.visualstudio.com/Minsk/_apis/build/status/terrajobst.minsk?branchName=master)](https://terrajobst.visualstudio.com/Minsk/_build/latest?definitionId=13)
 
 > Have you considered Minsk? -- Worf, naming things.
 


### PR DESCRIPTION
Following the advice from Andrew Lock [1] we should change the badge to only show the build result for the latest build in master as we usually don't care whether some PR build failed.

[1] https://andrewlock.net/building-an-open-source-github-project-using-azure-devops/#bonus-adding-build-badges-to-your-readme-md