### PR TITLE
Publish test results to azure pipelines

### DIFF
--- a/Minsk.Tests/Minsk.Tests.csproj
+++ b/Minsk.Tests/Minsk.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="XunitXML.TestLogger" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,5 +13,10 @@ variables:
 steps:
 - script: dotnet build --configuration $(buildConfiguration)
   displayName: 'dotnet build $(buildConfiguration)'
-- script: dotnet test $(tests)
+- script: dotnet test $(tests) --logger "xunit;LogFileName=TestResults.xml"
   displayName: 'dotnet test'
+- task: PublishTestResults@2
+  displayName: 'publish test results to azure pipelines'
+  inputs:
+    testResultsFormat: 'xUnit'
+    testResultsFiles: '**/TestResults.xml'


### PR DESCRIPTION
This PR will enable viewing test results in azure pipelines.

![grafik](https://user-images.githubusercontent.com/4410553/47564945-155a6e00-d927-11e8-96d2-82eb3233dcb0.png)

To enable this i added the [XunitXML.TestLogger](https://www.nuget.org/packages/XunitXml.TestLogger/) to the test project and modified the `azure-pipelines.yml`.