### PR TITLE
Removed local variable diagnostics in SyntaxTree constructor

### DIFF
--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -10,10 +10,9 @@ namespace Minsk.CodeAnalysis.Syntax
         {
             var parser = new Parser(text);
             var root = parser.ParseCompilationUnit();
-            var diagnostics = parser.Diagnostics.ToImmutableArray();
 
             Text = text;
-            Diagnostics = diagnostics;
+            Diagnostics = parser.Diagnostics.ToImmutableArray();
             Root = root;
         }
 


### PR DESCRIPTION
The declaration of a local variable diagnostics in the SyntaxTree constructor is not needed. Assigned Diagnostics from the parser directly to the Diagnostics property of the SyntaxTree.