### PR TITLE
Removed duplicate assignment of SyntaxTree in Compilation ctor

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -14,7 +14,6 @@ namespace Minsk.CodeAnalysis
         public Compilation(SyntaxTree syntaxTree)
             : this(null, syntaxTree)
         {
-            SyntaxTree = syntaxTree;
         }
 
         private Compilation(Compilation previous, SyntaxTree syntaxTree)


### PR DESCRIPTION
The parameter syntaxTree was assigned to the property SyntaxTree twice, once in both constructors of Compilation when only needs to be done once.