### PR TITLE
REPL command history

### DIFF
--- a/src/mc/Program.cs
+++ b/src/mc/Program.cs
@@ -16,6 +16,7 @@ namespace Minsk
             var variables = new Dictionary<VariableSymbol, object>();
             var textBuilder = new StringBuilder();
             Compilation previous = null;
+            ReadLine.HistoryEnabled = true;
 
             while (true)
             {
@@ -28,7 +29,7 @@ namespace Minsk
 
                 Console.ResetColor();
 
-                var input = Console.ReadLine();
+                var input = ReadLine.Read();
                 var isBlank = string.IsNullOrWhiteSpace(input);
 
                 if (textBuilder.Length == 0)

--- a/src/mc/mc.csproj
+++ b/src/mc/mc.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\Minsk\Minsk.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ReadLine" Version="2.0.1" />
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>


### PR DESCRIPTION
Kudos to https://github.com/tonerdo/readline, we now have command history with just 2 lines of code

![nov-16-2018 11-34-19](https://user-images.githubusercontent.com/25821724/48613399-46f9ae80-e994-11e8-9118-581b68919b0c.gif)

fixes https://github.com/terrajobst/minsk/issues/27