### PR TITLE
Evaluate the upper bound only once in a for loop

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -70,6 +70,7 @@ namespace Minsk.Tests.CodeAnalysis
         [InlineData("{ var a = 0 if a == 4 a = 10 else a = 5 a }", 5)]
         [InlineData("{ var i = 10 var result = 0 while i > 0 { result = result + i i = i - 1} result }", 55)]
         [InlineData("{ var result = 0 for i = 1 to 10 { result = result + i } result }", 55)]
+        [InlineData("{ var a = 10 for i = 1 to (a = a - 1) { } a }", 9)]
         public void Evaluator_Computes_CorrectValues(string text, object expectedValue)
         {
             AssertValue(text, expectedValue);


### PR DESCRIPTION
This matters if the upper bound expression has side effects.

NB: I targeted this PR to your episode branch, since it's not merged yet.