### PR TITLE
Remove double negation in BoundConditionalGotoStatement usage

### DIFF
--- a/src/Minsk/CodeAnalysis/Binding/BoundConditionalGotoStatement.cs
+++ b/src/Minsk/CodeAnalysis/Binding/BoundConditionalGotoStatement.cs
@@ -2,16 +2,16 @@ namespace Minsk.CodeAnalysis.Binding
 {
     internal sealed class BoundConditionalGotoStatement : BoundStatement
     {
-        public BoundConditionalGotoStatement(LabelSymbol label, BoundExpression condition, bool jumpIfFalse = false)
+        public BoundConditionalGotoStatement(LabelSymbol label, BoundExpression condition, bool jumpIfTrue = true)
         {
             Label = label;
             Condition = condition;
-            JumpIfFalse = jumpIfFalse;
+            JumpIfTrue = jumpIfTrue;
         }
 
         public override BoundNodeKind Kind => BoundNodeKind.ConditionalGotoStatement;
         public LabelSymbol Label { get; }
         public BoundExpression Condition { get; }
-        public bool JumpIfFalse { get; }
+        public bool JumpIfTrue { get; }
     }
 }

--- a/src/Minsk/CodeAnalysis/Binding/BoundTreeRewriter.cs
+++ b/src/Minsk/CodeAnalysis/Binding/BoundTreeRewriter.cs
@@ -118,7 +118,7 @@ namespace Minsk.CodeAnalysis.Binding
             if (condition == node.Condition)
                 return node;
 
-            return new BoundConditionalGotoStatement(node.Label, condition, node.JumpIfFalse);
+            return new BoundConditionalGotoStatement(node.Label, condition, node.JumpIfTrue);
         }
 
         protected virtual BoundStatement RewriteExpressionStatement(BoundExpressionStatement node)

--- a/src/Minsk/CodeAnalysis/Evaluator.cs
+++ b/src/Minsk/CodeAnalysis/Evaluator.cs
@@ -50,8 +50,7 @@ namespace Minsk.CodeAnalysis
                     case BoundNodeKind.ConditionalGotoStatement:
                         var cgs = (BoundConditionalGotoStatement)s;
                         var condition = (bool)EvaluateExpression(cgs.Condition);
-                        if (condition && !cgs.JumpIfFalse ||
-                            !condition && cgs.JumpIfFalse)
+                        if (condition == cgs.JumpIfTrue)
                             index = labelToIndex[cgs.Label];
                         else
                             index++;

--- a/src/Minsk/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Minsk/CodeAnalysis/Lowering/Lowerer.cs
@@ -64,7 +64,7 @@ namespace Minsk.CodeAnalysis.Lowering
                 // <then>  
                 // end:
                 var endLabel = GenerateLabel();
-                var gotoFalse = new BoundConditionalGotoStatement(endLabel, node.Condition, true);
+                var gotoFalse = new BoundConditionalGotoStatement(endLabel, node.Condition, false);
                 var endLabelStatement = new BoundLabelStatement(endLabel);
                 var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(gotoFalse, node.ThenStatement, endLabelStatement));
                 return RewriteStatement(result);
@@ -88,7 +88,7 @@ namespace Minsk.CodeAnalysis.Lowering
                 var elseLabel = GenerateLabel();
                 var endLabel = GenerateLabel();
 
-                var gotoFalse = new BoundConditionalGotoStatement(elseLabel, node.Condition, true);
+                var gotoFalse = new BoundConditionalGotoStatement(elseLabel, node.Condition, false);
                 var gotoEndStatement = new BoundGotoStatement(endLabel);
                 var elseLabelStatement = new BoundLabelStatement(elseLabel);
                 var endLabelStatement = new BoundLabelStatement(endLabel);
@@ -126,7 +126,7 @@ namespace Minsk.CodeAnalysis.Lowering
             var gotoCheck = new BoundGotoStatement(checkLabel);
             var continueLabelStatement = new BoundLabelStatement(continueLabel);
             var checkLabelStatement = new BoundLabelStatement(checkLabel);
-            var gotoTrue = new BoundConditionalGotoStatement(continueLabel, node.Condition, false);
+            var gotoTrue = new BoundConditionalGotoStatement(continueLabel, node.Condition);
             var endLabelStatement = new BoundLabelStatement(endLabel);
 
             var result = new BoundBlockStatement(ImmutableArray.Create<BoundStatement>(


### PR DESCRIPTION
Ok, this is a suggestion, but `BoundConditionalGotoStatement` uses a double negation to convey its meaning, which I find unnatural when reading such code:

![image](https://user-images.githubusercontent.com/7913492/49299533-3bdc6d80-f4c0-11e8-9b39-79eab9495860.png)

This replaces `JumpIfFalse` with `JumpIfTrue` which removes the double negation.

NB: I targeted this PR to your episode branch, since it's not merged yet.