### PR TITLE
Enforce underscore prefix for fields

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,11 @@
+[*.{cs,vb}]
+
+dotnet_naming_rule.private_fields_start_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_start_with_underscore.style = starts_with_underscore
+dotnet_naming_rule.private_fields_start_with_underscore.severity = warning
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.starts_with_underscore.capitalization = camel_case
+dotnet_naming_style.starts_with_underscore.required_prefix = _


### PR DESCRIPTION
This will make sure that the IDE & VS Code generate fields with an underscore prefix when using refactorings such as "Create and initialize field" so you don't have to fix this up later. Not only that, but it will also stop inserting `this.` :100:

Before:
![image](https://user-images.githubusercontent.com/11444821/50113710-0a46fe80-0243-11e9-9150-06bcc54ef79c.png)

After:
![image](https://user-images.githubusercontent.com/11444821/50113715-0d41ef00-0243-11e9-83fc-c6e14b067e49.png)
