### PR TITLE
Check whether the last token is missing as opposed to a looking for arbitrary syntax errors

### DIFF
--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxToken.cs
@@ -17,5 +17,10 @@ namespace Minsk.CodeAnalysis.Syntax
         public string Text { get; }
         public object Value { get; }
         public override TextSpan Span => new TextSpan(Position, Text?.Length ?? 0);
+
+        /// <summary>
+        /// A token is missing if it was inserted by the parser and doesn't appear in source.
+        /// </summary>
+        public bool IsMissing => Text == null;
     }
 }

--- a/src/mc/MinskRepl.cs
+++ b/src/mc/MinskRepl.cs
@@ -65,10 +65,20 @@ namespace Minsk
 
             var syntaxTree = SyntaxTree.Parse(text);
 
-            if (syntaxTree.Diagnostics.Any())
+            // Use Statement because we need to exclude the EndOfFileToken.
+            if (GetLastToken(syntaxTree.Root.Statement).IsMissing)
                 return false;
             
             return true;
+        }
+
+        private static SyntaxToken GetLastToken(SyntaxNode node)
+        {
+            if (node is SyntaxToken token)
+                return token;
+
+            // A syntax node should always contain at least 1 token.
+            return GetLastToken(node.GetChildren().Last());
         }
 
         protected override void EvaluateSubmission(string text)


### PR DESCRIPTION
The current check for whether the submission is incomplete is simply looking for any syntax errors. This often results in false positives because syntax errors could be arbitrarily deep in the tree and/or unrelated to the fact that I haven't finished typing.

For example: typing something like `(1 + )` and hitting enter will result in ever adding more blank lines because there's nothing I could do at this point to fix the error. In this case the error was made accidentally as opposed to being an incomplete submission.

After this PR, typing `(1 + )` will submit and show the syntax error. Similarly with things like `1a` or `{ var a = 1; }`. Basically this PR should result in a much better experience when you make typos because it will alert you of the error as opposed to an unexpected new line.

Note that this still works correctly for cases like `1 +` and `{ { var a = 1 }` (enters a new line instead of a submission) . Checking whether the last token is missing should be a much better heuristic for determining that the input is "incomplete". The token was inserted because the parser expected to see something (a continuation) but found the end of the input.