### PR TITLE
rename parameter to parameters (plural)

### DIFF
--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -307,16 +307,16 @@ namespace Minsk.CodeAnalysis.Binding
                 return new BoundErrorExpression();
             }
 
-            if (syntax.Arguments.Count != function.Parameter.Length)
+            if (syntax.Arguments.Count != function.Parameters.Length)
             {
-                _diagnostics.ReportWrongArgumentCount(syntax.Span, function.Name, function.Parameter.Length, syntax.Arguments.Count);
+                _diagnostics.ReportWrongArgumentCount(syntax.Span, function.Name, function.Parameters.Length, syntax.Arguments.Count);
                 return new BoundErrorExpression();
             }
 
             for (var i = 0; i < syntax.Arguments.Count; i++)
             {
                 var argument = boundArguments[i];
-                var parameter = function.Parameter[i];
+                var parameter = function.Parameters[i];
 
                 if (argument.Type != parameter.Type)
                 {

--- a/src/Minsk/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Minsk/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -4,15 +4,15 @@ namespace Minsk.CodeAnalysis.Symbols
 {
     public sealed class FunctionSymbol : Symbol
     {
-        public FunctionSymbol(string name, ImmutableArray<ParameterSymbol> parameter, TypeSymbol type)
+        public FunctionSymbol(string name, ImmutableArray<ParameterSymbol> parameters, TypeSymbol type)
             : base(name)
         {
-            Parameter = parameter;
+            Parameters = parameters;
             Type = type;
         }
 
         public override SymbolKind Kind => SymbolKind.Function;
-        public ImmutableArray<ParameterSymbol> Parameter { get; }
+        public ImmutableArray<ParameterSymbol> Parameters { get; }
         public TypeSymbol Type { get; }
     }
 }


### PR DESCRIPTION
I think that 'Parameters' would be better in plural (you named it also Arguments when calling a function).
