### PR TITLE
Use a single namespace for all symbol types

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -92,7 +92,7 @@ namespace Minsk.Tests.CodeAnalysis
             ";
 
             var diagnostics = @"
-                Variable 'x' is already declared.
+                'x' is already declared.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -280,6 +280,23 @@ namespace Minsk.Tests.CodeAnalysis
             AssertDiagnostics(text, diagnostics);
         }
 
+        [Fact]
+        public void Evaluator_Variables_Can_Shadow_Functions()
+        {
+            var text = @"
+                {
+                    let print = 42
+                    [print](""test"")
+                }
+            ";
+
+            var diagnostics = @"
+                Function 'print' doesn't exist.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
         private static void AssertValue(string text, object expectedValue)
         {
             var syntaxTree = SyntaxTree.Parse(text);

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -348,7 +348,7 @@ namespace Minsk.CodeAnalysis.Binding
             var variable = new VariableSymbol(name, isReadOnly, type);
 
             if (declare && !_scope.TryDeclareVariable(variable))
-                _diagnostics.ReportVariableAlreadyDeclared(identifier.Span, name);
+                _diagnostics.ReportSymbolAlreadyDeclared(identifier.Span, name);
 
             return variable;
         }

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -75,9 +75,9 @@ namespace Minsk.CodeAnalysis
             Report(span, message);
         }
 
-        public void ReportVariableAlreadyDeclared(TextSpan span, string name)
+        public void ReportSymbolAlreadyDeclared(TextSpan span, string name)
         {
-            var message = $"Variable '{name}' is already declared.";
+            var message = $"'{name}' is already declared.";
             Report(span, message);
         }
 


### PR DESCRIPTION
I'm not sure if that's something you'd actually want to change, but this PR prevents variables and functions from having the same name, which could be confusing. As an added bonus, there's less code duplication.

You can still shadow a symbol defined in an outer scope, even if it's of a different type, as shadowing was an intended feature.

Before:

![image](https://user-images.githubusercontent.com/7913492/57571401-01cbac00-740e-11e9-90ab-f47cb91b436f.png)

After:

![image](https://user-images.githubusercontent.com/7913492/57571411-1445e580-740e-11e9-8bb6-d15b9f3861b8.png)
