### PR TITLE
Sort diagnostics by span before showing them

### DIFF
--- a/src/mc/MinskRepl.cs
+++ b/src/mc/MinskRepl.cs
@@ -117,7 +117,7 @@ namespace Minsk
             }
             else
             {
-                foreach (var diagnostic in result.Diagnostics)
+                foreach (var diagnostic in result.Diagnostics.OrderBy(diag => diag.Span, new TextSpanComparer()))
                 {
                     var lineIndex = syntaxTree.Text.GetLineIndex(diagnostic.Span.Start);
                     var line = syntaxTree.Text.Lines[lineIndex];

--- a/src/mc/TextSpanComparer.cs
+++ b/src/mc/TextSpanComparer.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Minsk.CodeAnalysis.Text;
+
+namespace Minsk
+{
+    internal class TextSpanComparer : IComparer<TextSpan>
+    {
+        public int Compare(TextSpan x, TextSpan y)
+        {
+            int cmp = x.Start - y.Start;
+            if (cmp == 0)
+                cmp = x.Length - y.Length;
+            return cmp;
+        }
+    }
+}


### PR DESCRIPTION
This is in order to display diagnostic messages ordered by occurrence in the input.

e.g. for the input "x = 10 * y" the following diagnostics are displayed:

(1, 10): Variable 'y' doesn't exist.
    x = 10 * **y**

(1, 1): Variable 'x' doesn't exist.
    **x** = 10 * y

It makes more sense to show them in the reverse order. This pull request orders diagnostic messages by the span property.

