### PR TITLE
Update ignore pattern for NCrunch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchsolution
+*.ncrunchproject
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
I'm using NCrunch for running the tests, and the keep popping up as untracked files, however, they're safe to ignore since you don't need to customize it (runs out of the box for this solution). The default Visual Studio gitignore already ignores NCrunch generated files, but it's a bit outdated.