### PR TITLE
Minor fixes to binding of call arguments

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -122,6 +122,34 @@ namespace Minsk.Tests.CodeAnalysis
         }
 
         [Fact]
+        public void Evaluator_InvokeFunctionArguments_Missing()
+        {
+            var text = @"
+                print([)]
+            ";
+
+            var diagnostics = @"
+                Function 'print' requires 1 arguments but was given 0.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_InvokeFunctionArguments_Exceeding()
+        {
+            var text = @"
+                print(""Hello""[, "" "", "" world!""])
+            ";
+
+            var diagnostics = @"
+                Function 'print' requires 1 arguments but was given 3.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
         public void Evaluator_InvokeFunctionArguments_NoInfiniteLoop()
         {
             var text = @"

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -455,7 +455,22 @@ namespace Minsk.CodeAnalysis.Binding
 
             if (syntax.Arguments.Count != function.Parameters.Length)
             {
-                _diagnostics.ReportWrongArgumentCount(syntax.Span, function.Name, function.Parameters.Length, syntax.Arguments.Count);
+                TextSpan span;
+                if (syntax.Arguments.Count > function.Parameters.Length)
+                {
+                    SyntaxNode firstExceedingNode;
+                    if (function.Parameters.Length > 0)
+                        firstExceedingNode = syntax.Arguments.GetSeparator(function.Parameters.Length - 1);
+                    else
+                        firstExceedingNode = syntax.Arguments[0];
+                    var lastExceedingArgument = syntax.Arguments[syntax.Arguments.Count - 1];
+                    span = TextSpan.FromBounds(firstExceedingNode.Span.Start, lastExceedingArgument.Span.End);
+                }
+                else
+                {
+                    span = syntax.CloseParenthesisToken.Span;
+                }
+                _diagnostics.ReportWrongArgumentCount(span, function.Name, function.Parameters.Length, syntax.Arguments.Count);
                 return new BoundErrorExpression();
             }
 

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -474,6 +474,7 @@ namespace Minsk.CodeAnalysis.Binding
                 return new BoundErrorExpression();
             }
 
+            bool hasErrors = false;
             for (var i = 0; i < syntax.Arguments.Count; i++)
             {
                 var argument = boundArguments[i];
@@ -482,9 +483,11 @@ namespace Minsk.CodeAnalysis.Binding
                 if (argument.Type != parameter.Type)
                 {
                     _diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Span, parameter.Name, parameter.Type, argument.Type);
-                   return new BoundErrorExpression();
+                    hasErrors = true;
                 }
             }
+            if (hasErrors)
+                return new BoundErrorExpression();
 
             return new BoundCallExpression(function, boundArguments.ToImmutable());
         }

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -482,7 +482,8 @@ namespace Minsk.CodeAnalysis.Binding
 
                 if (argument.Type != parameter.Type)
                 {
-                    _diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Span, parameter.Name, parameter.Type, argument.Type);
+                    if (argument.Type != TypeSymbol.Error)
+                        _diagnostics.ReportWrongArgumentType(syntax.Arguments[i].Span, parameter.Name, parameter.Type, argument.Type);
                     hasErrors = true;
                 }
             }


### PR DESCRIPTION
Fixed the highlighted span location for exceeding/missing arguments.
Also report errors for every mismatching argument type, ignoring arguments of unbound error expressions.