### PR TITLE
Fix an exception when functionname is empty. Also added evaluator tests.

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -69,6 +69,7 @@ namespace Minsk.Tests.CodeAnalysis
         [InlineData("\"test\" != \"test\"", false)]
         [InlineData("\"test\" == \"abc\"", false)]
         [InlineData("\"test\" != \"abc\"", true)]
+        [InlineData("\"test\" + \"abc\"", "testabc")]
         [InlineData("{ var a = 10 (a * a) }", 100)]
         [InlineData("{ var a = 0 (a = 10) * a }", 100)]
         [InlineData("{ var a = 0 if a == 0 a = 10 a }", 10)]
@@ -385,6 +386,172 @@ namespace Minsk.Tests.CodeAnalysis
 
             var diagnostics = @"
                 Function 'print' doesn't exist.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Void_Function_Should_Not_Return_Value()
+        {
+            var text = @"
+                function test()
+                {
+                    return [1]
+                }
+            ";
+
+            var diagnostics = @"
+                Since the function 'test' does not return a value the 'return' keyword cannot be followed by an expression.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Function_With_ReturnValue_Should_Not_Return_Void()
+        {
+            var text = @"
+                function test(): int
+                {
+                    [return]
+                }
+            ";
+
+            var diagnostics = @"
+                An expression of type 'int' expected.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Not_All_Code_Paths_Return_Value()
+        {
+            var text = @"
+                function [test](n: int): bool
+                {
+                    if (n > 10)
+                       return true
+                }
+            ";
+
+            var diagnostics = @"
+                Not all code paths return a value.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Expression_Must_Have_Value()
+        {
+            var text = @"
+                function test(n: int)
+                {
+                    return
+                }
+
+                let value = [test(100)]
+            ";
+
+            var diagnostics = @"
+                Expression must have a value.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Theory]
+        [InlineData("[break]", "break")]
+        [InlineData("[continue]", "continue")]
+        public void Evaluator_Invalid_Break_Or_Continue(string text, string keyword)
+        {
+            var diagnostics = $@"
+                The keyword '{keyword}' can only be used inside of loops.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Invalid_Return()
+        {
+            var text = @"
+                [return]
+            ";
+
+            var diagnostics = @"
+                The 'return' keyword can only be used inside of functions.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Parameter_Already_Declared()
+        {
+            var text = @"
+                function sum(a: int, b: int, [a: int]): int
+                {
+                    return a + b + c
+                }
+            ";
+
+            var diagnostics = @"
+                A parameter with the name 'a' already exists.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Function_Must_Have_Name()
+        {
+            var text = @"
+                function [(]a: int, b: int): int
+                {
+                    return a + b
+                }
+            ";
+
+            var diagnostics = @"
+                Unexpected token <OpenParenthesisToken>, expected <IdentifierToken>.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Wrong_Argument_Type()
+        {
+            var text = @"
+                function test(n: int): bool
+                {
+                    return n > 10
+                }
+                let testValue = ""string""
+                test([testValue])
+            ";
+
+            var diagnostics = @"
+                Parameter 'n' requires a value of type 'int' but was given a value of type 'string'.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void Evaluator_Bad_Type()
+        {
+            var text = @"
+                function test(n: [invalidtype])
+                {
+                }
+            ";
+
+            var diagnostics = @"
+                Type 'invalidtype' doesn't exist.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -113,8 +113,11 @@ namespace Minsk.CodeAnalysis.Binding
             var type = BindTypeClause(syntax.Type) ?? TypeSymbol.Void;
 
             var function = new FunctionSymbol(syntax.Identifier.Text, parameters.ToImmutable(), type, syntax);
-            if (!_scope.TryDeclareFunction(function))
+            if (function.Declaration.Identifier.Text != null &&
+                !_scope.TryDeclareFunction(function))
+            {
                 _diagnostics.ReportSymbolAlreadyDeclared(syntax.Identifier.Span, function.Name);
+            }
         }
 
         private static BoundScope CreateParentScope(BoundGlobalScope previous)


### PR DESCRIPTION
I have found an exception in the evaluator when you create a function without a name. So:
```
function (): bool
{
    return true
}
```
The syntax-tree will contain an error (found '(' but expected identifier). But in the Evaluator it will still crash.

Also added some other Evaluator tests to test more function-related diagnostics.