### PR TITLE
Some minor changes

### DIFF
--- a/src/Minsk/CodeAnalysis/Binding/BoundNodePrinter.cs
+++ b/src/Minsk/CodeAnalysis/Binding/BoundNodePrinter.cs
@@ -214,16 +214,20 @@ namespace Minsk.CodeAnalysis.Binding
 
         private static void WriteGotoStatement(BoundGotoStatement node, IndentedTextWriter writer)
         {
-            writer.WriteKeyword("goto ");
+            writer.WriteKeyword("goto"); // There is no SyntaxKind for goto
+            writer.WriteSpace();
             writer.WriteIdentifier(node.Label.Name);
             writer.WriteLine();
         }
 
         private static void WriteConditionalGotoStatement(BoundConditionalGotoStatement node, IndentedTextWriter writer)
         {
-            writer.WriteKeyword("goto ");
+            writer.WriteKeyword("goto"); // There is no SyntaxKind for goto
+            writer.WriteSpace();
             writer.WriteIdentifier(node.Label.Name);
-            writer.WriteKeyword(node.JumpIfTrue ? " if " : " unless ");
+            writer.WriteSpace();
+            writer.WriteKeyword(node.JumpIfTrue ? "if" : "unless");
+            writer.WriteSpace();
             node.Condition.WriteTo(writer);
             writer.WriteLine();
         }

--- a/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -1,8 +1,8 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Minsk.CodeAnalysis.Symbols;
 using Minsk.CodeAnalysis.Syntax;
 
@@ -50,9 +50,10 @@ namespace Minsk.CodeAnalysis.Binding
                     return "<End>";
 
                 using (var writer = new StringWriter())
+                using (var indentedWriter = new IndentedTextWriter(writer))
                 {
                     foreach (var statement in Statements)
-                        statement.WriteTo(writer);
+                        statement.WriteTo(indentedWriter);
 
                     return writer.ToString();
                 }
@@ -177,7 +178,7 @@ namespace Minsk.CodeAnalysis.Binding
                                 var cgs = (BoundConditionalGotoStatement)statement;
                                 var thenBlock = _blockFromLabel[cgs.Label];
                                 var elseBlock = next;
-                                var negatedCondition = Negate(cgs.Condition);;
+                                var negatedCondition = Negate(cgs.Condition);
                                 var thenCondition = cgs.JumpIfTrue ? cgs.Condition : negatedCondition;
                                 var elseCondition = cgs.JumpIfTrue ? negatedCondition : cgs.Condition;
                                 Connect(current, thenBlock, thenCondition);
@@ -265,7 +266,7 @@ namespace Minsk.CodeAnalysis.Binding
         {
             string Quote(string text)
             {
-                return "\"" + text.Replace("\"", "\\\"") + "\"";
+                return "\"" + text.TrimEnd().Replace("\\", "\\\\").Replace("\"", "\\\"").Replace(Environment.NewLine, "\\l") + "\"";
             }
 
             writer.WriteLine("digraph G {");
@@ -281,8 +282,8 @@ namespace Minsk.CodeAnalysis.Binding
             foreach (var block in Blocks)
             {
                 var id = blockIds[block];
-                var label = Quote(block.ToString().Replace(Environment.NewLine, "\\l"));
-                writer.WriteLine($"    {id} [label = {label} shape = box]");
+                var label = Quote(block.ToString());
+                writer.WriteLine($"    {id} [label = {label}, shape = box]");
             }
 
             foreach (var branch in Branches)

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -155,7 +155,7 @@ namespace Minsk.CodeAnalysis
 
         public void ReportMissingReturnExpression(TextSpan span, TypeSymbol returnType)
         {
-            var message = $"An expression of type '{returnType}' expected.";
+            var message = $"An expression of type '{returnType}' is expected.";
             Report(span, message);
         }
     }


### PR DESCRIPTION
- Escape backslashes in dot files - I found inconsistencies in the Graphviz docs in this regard, but dot won't display a backslash in the generated graph unless you escape it
- Use an `IndentedTextWriter` for graph node labels, otherwise one would be created automatically for each label
- You [can use commas or semicolons](https://www.graphviz.org/doc/info/lang.html) to separate attributes in dot files, so use a comma
- Fixed diagnostic message