### PR TITLE
Better error messages for mismatched symbol types

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -338,6 +338,18 @@ namespace Minsk.Tests.CodeAnalysis
 
             AssertDiagnostics(text, diagnostics);
         }
+        
+        [Fact]
+        public void Evaluator_AssignmentExpression_Reports_NotAVariable()
+        {
+            var text = @"[print] = 42";
+
+            var diagnostics = @"
+                'print' is not a variable.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
 
         [Fact]
         public void Evaluator_AssignmentExpression_Reports_CannotAssign()
@@ -372,6 +384,35 @@ namespace Minsk.Tests.CodeAnalysis
 
             AssertDiagnostics(text, diagnostics);
         }
+        
+        [Fact]
+        public void Evaluator_CallExpression_Reports_Undefined()
+        {
+            var text = @"[foo](42)";
+
+            var diagnostics = @"
+                Function 'foo' doesn't exist.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+        
+        [Fact]
+        public void Evaluator_CallExpression_Reports_NotAFunction()
+        {
+            var text = @"
+                {
+                    let foo = 42
+                    [foo](42)
+                }
+            ";
+
+            var diagnostics = @"
+                'foo' is not a function.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
 
         [Fact]
         public void Evaluator_Variables_Can_Shadow_Functions()
@@ -384,7 +425,7 @@ namespace Minsk.Tests.CodeAnalysis
             ";
 
             var diagnostics = @"
-                Function 'print' doesn't exist.
+                'print' is not a function.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -213,7 +213,7 @@ namespace Minsk.CodeAnalysis.Binding
             var type = BindTypeClause(syntax.TypeClause);
             var initializer = BindExpression(syntax.Initializer);
             var variableType = type ?? initializer.Type;
-            var variable = BindVariable(syntax.Identifier, isReadOnly, variableType);
+            var variable = BindVariableDeclaration(syntax.Identifier, isReadOnly, variableType);
             var convertedInitializer = BindConversion(syntax.Initializer.Span, initializer, variableType);
 
             return new BoundVariableDeclaration(variable, convertedInitializer);
@@ -260,7 +260,7 @@ namespace Minsk.CodeAnalysis.Binding
 
             _scope = new BoundScope(_scope);
 
-            var variable = BindVariable(syntax.Identifier, isReadOnly: true, TypeSymbol.Int);
+            var variable = BindVariableDeclaration(syntax.Identifier, isReadOnly: true, TypeSymbol.Int);
             var body = BindLoopBody(syntax.Body, out var breakLabel, out var continueLabel);
 
             _scope = _scope.Parent;
@@ -399,11 +399,9 @@ namespace Minsk.CodeAnalysis.Binding
                 return new BoundErrorExpression();
             }
 
-            if (!_scope.TryLookupVariable(name, out var variable))
-            {
-                _diagnostics.ReportUndefinedName(syntax.IdentifierToken.Span, name);
+            var variable = BindVariableReference(name, syntax.IdentifierToken.Span);
+            if (variable == null)
                 return new BoundErrorExpression();
-            }
 
             return new BoundVariableExpression(variable);
         }
@@ -413,11 +411,9 @@ namespace Minsk.CodeAnalysis.Binding
             var name = syntax.IdentifierToken.Text;
             var boundExpression = BindExpression(syntax.Expression);
 
-            if (!_scope.TryLookupVariable(name, out var variable))
-            {
-                _diagnostics.ReportUndefinedName(syntax.IdentifierToken.Span, name);
+            var variable = BindVariableReference(name, syntax.IdentifierToken.Span);
+            if (variable == null)
                 return boundExpression;
-            }
 
             if (variable.IsReadOnly)
                 _diagnostics.ReportCannotAssign(syntax.EqualsToken.Span, name);
@@ -477,9 +473,17 @@ namespace Minsk.CodeAnalysis.Binding
                 boundArguments.Add(boundArgument);
             }
 
-            if (!_scope.TryLookupFunction(syntax.Identifier.Text, out var function))
+            var symbol = _scope.TryLookupSymbol(syntax.Identifier.Text);
+            if (symbol == null)
             {
                 _diagnostics.ReportUndefinedFunction(syntax.Identifier.Span, syntax.Identifier.Text);
+                return new BoundErrorExpression();
+            }
+            
+            var function = symbol as FunctionSymbol;
+            if (function == null)
+            {
+                _diagnostics.ReportNotAFunction(syntax.Identifier.Span, syntax.Identifier.Text);
                 return new BoundErrorExpression();
             }
 
@@ -552,7 +556,7 @@ namespace Minsk.CodeAnalysis.Binding
             return new BoundConversionExpression(type, expression);
         }
 
-        private VariableSymbol BindVariable(SyntaxToken identifier, bool isReadOnly, TypeSymbol type)
+        private VariableSymbol BindVariableDeclaration(SyntaxToken identifier, bool isReadOnly, TypeSymbol type)
         {
             var name = identifier.Text ?? "?";
             var declare = !identifier.IsMissing;
@@ -564,6 +568,23 @@ namespace Minsk.CodeAnalysis.Binding
                 _diagnostics.ReportSymbolAlreadyDeclared(identifier.Span, name);
 
             return variable;
+        }
+
+        private VariableSymbol BindVariableReference(string name, TextSpan span)
+        {
+            switch (_scope.TryLookupSymbol(name))
+            {
+                case VariableSymbol variable:
+                    return variable;
+
+                case null:
+                    _diagnostics.ReportUndefinedVariable(span, name);
+                    return null;
+
+                default:
+                    _diagnostics.ReportNotAVariable(span, name);
+                    return null;
+            }
         }
 
         private TypeSymbol LookupType(string name)

--- a/src/Minsk/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Minsk/CodeAnalysis/Binding/BoundScope.cs
@@ -34,32 +34,12 @@ namespace Minsk.CodeAnalysis.Binding
             return true;
         }
 
-        public bool TryLookupVariable(string name, out VariableSymbol variable)
-            => TryLookupSymbol(name, out variable);
-
-        public bool TryLookupFunction(string name, out FunctionSymbol function)
-            => TryLookupSymbol(name, out function);
-
-        private bool TryLookupSymbol<TSymbol>(string name, out TSymbol symbol)
-            where TSymbol : Symbol
+        public Symbol TryLookupSymbol(string name)
         {
-            symbol = null;
+            if (_symbols != null && _symbols.TryGetValue(name, out var symbol))
+                return symbol;
 
-            if (_symbols != null && _symbols.TryGetValue(name, out var declaredSymbol))
-            {
-                if (declaredSymbol is TSymbol matchingSymbol)
-                {
-                    symbol = matchingSymbol;
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (Parent == null)
-                return false;
-
-            return Parent.TryLookupSymbol(name, out symbol);
+            return Parent?.TryLookupSymbol(name);
         }
 
         public ImmutableArray<VariableSymbol> GetDeclaredVariables()

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -69,9 +69,15 @@ namespace Minsk.CodeAnalysis
             Report(span, message);
         }
 
-        public void ReportUndefinedName(TextSpan span, string name)
+        public void ReportUndefinedVariable(TextSpan span, string name)
         {
             var message = $"Variable '{name}' doesn't exist.";
+            Report(span, message);
+        }
+        
+        public void ReportNotAVariable(TextSpan span, string name)
+        {
+            var message = $"'{name}' is not a variable.";
             Report(span, message);
         }
 
@@ -108,6 +114,12 @@ namespace Minsk.CodeAnalysis
         public void ReportUndefinedFunction(TextSpan span, string name)
         {
             var message = $"Function '{name}' doesn't exist.";
+            Report(span, message);
+        }
+        
+        public void ReportNotAFunction(TextSpan span, string name)
+        {
+            var message = $"'{name}' is not a function.";
             Report(span, message);
         }
 


### PR DESCRIPTION
This is a follow-up to #54. I wasn't sure if you were going to accept that one so I didn't polish the diagnostics. This PR fixes this.
