### PR TITLE
Fix control flow evaluation for empty functions

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/EvaluationTests.cs
@@ -189,6 +189,22 @@ namespace Minsk.Tests.CodeAnalysis
         }
 
         [Fact]
+        public void Evaluator_FunctionReturn_Missing()
+        {
+            var text = @"
+                function [add](a: int, b: int): int
+                {
+                }
+            ";
+
+            var diagnostics = @"
+                Not all code paths return a value.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
         public void Evaluator_IfStatement_Reports_CannotConvert()
         {
             var text = @"

--- a/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -177,7 +177,7 @@ namespace Minsk.CodeAnalysis.Binding
                                 var cgs = (BoundConditionalGotoStatement)statement;
                                 var thenBlock = _blockFromLabel[cgs.Label];
                                 var elseBlock = next;
-                                var negatedCondition = Negate(cgs.Condition);;
+                                var negatedCondition = Negate(cgs.Condition);
                                 var thenCondition = cgs.JumpIfTrue ? cgs.Condition : negatedCondition;
                                 var elseCondition = cgs.JumpIfTrue ? negatedCondition : cgs.Condition;
                                 Connect(current, thenBlock, thenCondition);

--- a/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Minsk/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -311,8 +311,8 @@ namespace Minsk.CodeAnalysis.Binding
 
             foreach (var branch in graph.End.Incoming)
             {
-                var lastStatement = branch.From.Statements.Last();
-                if (lastStatement.Kind != BoundNodeKind.ReturnStatement)
+                var lastStatement = branch.From.Statements.LastOrDefault();
+                if (lastStatement == null || lastStatement.Kind != BoundNodeKind.ReturnStatement)
                     return false;
             }
 


### PR DESCRIPTION
Fixed an exception while evaluating control flow for empty functions. e.g.

```
function add(a: int, b: int): int
{
}
```
When the body of the function is empty, the `BasicBlock` for the function has no statements. When `AllPathsReturn` tries to get the last statement to check it is a `BoundNodeKind.ReturnStatement`, an exception is thrown because the sequence is empty.

`Unhandled Exception: System.InvalidOperationException: Sequence contains no elements`