### PR TITLE
Fix solution filename casing on tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/src/Minsk.sln"
+                "${workspaceFolder}/src/minsk.sln"
             ],
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
Now we can launch debugger on linux.