### PR TITLE
Keep track of the original SourceText that raised a diagnostic message

### DIFF
--- a/src/Minsk/CodeAnalysis/Binding/BoundGlobalScope.cs
+++ b/src/Minsk/CodeAnalysis/Binding/BoundGlobalScope.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
 using Minsk.CodeAnalysis.Symbols;
+using Minsk.CodeAnalysis.Text;
 
 namespace Minsk.CodeAnalysis.Binding
 {
     internal sealed class BoundGlobalScope
     {
-        public BoundGlobalScope(BoundGlobalScope previous, ImmutableArray<Diagnostic> diagnostics, ImmutableArray<FunctionSymbol> functions, ImmutableArray<VariableSymbol> variables, ImmutableArray<BoundStatement> statements)
+        public BoundGlobalScope(SourceText text, BoundGlobalScope previous, ImmutableArray<Diagnostic> diagnostics, ImmutableArray<FunctionSymbol> functions, ImmutableArray<VariableSymbol> variables, ImmutableArray<BoundStatement> statements)
         {
+            Text = text;
             Previous = previous;
             Diagnostics = diagnostics;
             Functions = functions;
@@ -14,6 +16,7 @@ namespace Minsk.CodeAnalysis.Binding
             Statements = statements;
         }
 
+        public SourceText Text { get; }
         public BoundGlobalScope Previous { get; }
         public ImmutableArray<Diagnostic> Diagnostics { get; }
         public ImmutableArray<FunctionSymbol> Functions { get; }

--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -35,7 +35,7 @@ namespace Minsk.CodeAnalysis
             {
                 if (_globalScope == null)
                 {
-                    var globalScope = Binder.BindGlobalScope(Previous?.GlobalScope, SyntaxTree.Root);
+                    var globalScope = Binder.BindGlobalScope(SyntaxTree.Text, Previous?.GlobalScope, SyntaxTree.Root);
                     Interlocked.CompareExchange(ref _globalScope, globalScope, null);
                 }
 

--- a/src/Minsk/CodeAnalysis/Diagnostic.cs
+++ b/src/Minsk/CodeAnalysis/Diagnostic.cs
@@ -4,12 +4,14 @@ namespace Minsk.CodeAnalysis
 {
     public sealed class Diagnostic
     {
-        public Diagnostic(TextSpan span, string message)
+        public Diagnostic(SourceText text, TextSpan span, string message)
         {
+            Text = text;
             Span = span;
             Message = message;
         }
 
+        public SourceText Text { get; }
         public TextSpan Span { get; }
         public string Message { get; }
 

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -9,7 +9,15 @@ namespace Minsk.CodeAnalysis
 {
     internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
     {
-        private readonly List<Diagnostic> _diagnostics = new List<Diagnostic>();
+        private readonly List<Diagnostic> _diagnostics;
+
+        public DiagnosticBag(SourceText text)
+        {
+            Text = text;
+            _diagnostics = new List<Diagnostic>();
+        }
+
+        public SourceText Text {get;}
 
         public IEnumerator<Diagnostic> GetEnumerator() => _diagnostics.GetEnumerator();
 
@@ -22,7 +30,7 @@ namespace Minsk.CodeAnalysis
 
         private void Report(TextSpan span, string message)
         {
-            var diagnostic = new Diagnostic(span, message);
+            var diagnostic = new Diagnostic(Text, span, message);
             _diagnostics.Add(diagnostic);
         }
 

--- a/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
@@ -7,7 +7,7 @@ namespace Minsk.CodeAnalysis.Syntax
 {
     internal sealed class Lexer
     {
-        private readonly DiagnosticBag _diagnostics = new DiagnosticBag();
+        private readonly DiagnosticBag _diagnostics;
         private readonly SourceText _text;
 
         private int _position;
@@ -18,6 +18,7 @@ namespace Minsk.CodeAnalysis.Syntax
 
         public Lexer(SourceText text)
         {
+            _diagnostics = new DiagnosticBag(text);
             _text = text;
         }
 

--- a/src/Minsk/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/Parser.cs
@@ -7,7 +7,7 @@ namespace Minsk.CodeAnalysis.Syntax
 {
     internal sealed class Parser
     {
-        private readonly DiagnosticBag _diagnostics = new DiagnosticBag();
+        private readonly DiagnosticBag _diagnostics;
         private readonly SourceText _text;
         private readonly ImmutableArray<SyntaxToken> _tokens;
         private int _position;
@@ -29,6 +29,7 @@ namespace Minsk.CodeAnalysis.Syntax
                 }
             } while (token.Kind != SyntaxKind.EndOfFileToken);
 
+            _diagnostics = new DiagnosticBag(text);
             _text = text;
             _tokens = tokens.ToImmutableArray();
             _diagnostics.AddRange(lexer.Diagnostics);

--- a/src/mi/MinskRepl.cs
+++ b/src/mi/MinskRepl.cs
@@ -119,8 +119,8 @@ namespace Minsk
             {
                 foreach (var diagnostic in result.Diagnostics.OrderBy(diag => diag.Span, new TextSpanComparer()))
                 {
-                    var lineIndex = syntaxTree.Text.GetLineIndex(diagnostic.Span.Start);
-                    var line = syntaxTree.Text.Lines[lineIndex];
+                    var lineIndex = diagnostic.Text.GetLineIndex(diagnostic.Span.Start);
+                    var line = diagnostic.Text.Lines[lineIndex];
                     var lineNumber = lineIndex + 1;
                     var character = diagnostic.Span.Start - line.Start + 1;
 
@@ -134,9 +134,9 @@ namespace Minsk
                     var prefixSpan = TextSpan.FromBounds(line.Start, diagnostic.Span.Start);
                     var suffixSpan = TextSpan.FromBounds(diagnostic.Span.End, line.End);
 
-                    var prefix = syntaxTree.Text.ToString(prefixSpan);
-                    var error = syntaxTree.Text.ToString(diagnostic.Span);
-                    var suffix = syntaxTree.Text.ToString(suffixSpan);
+                    var prefix = diagnostic.Text.ToString(prefixSpan);
+                    var error = diagnostic.Text.ToString(diagnostic.Span);
+                    var suffix = diagnostic.Text.ToString(suffixSpan);
 
                     Console.Write("    ");
                     Console.Write(prefix);


### PR DESCRIPTION
This fixes an exception in repl when trying to highlight the span location of a diagnostic message when a symbol is redefined that affects a previously declared function.

Given the following sequence of inputs:
`let x = true`

`function f() { if x {} }`

If at this point you enter:
`let x = "Hi!"`

The error message is displayed

> (1, 19): Cannot convert type 'string' to 'bool'. An explicit conversion exists (are you missing a cast?)

Followed by an `System.ArgumentOutOfRangeException`

> Unhandled Exception: System.ArgumentOutOfRangeException: Index and length must refer to a location within the string.
> Parameter name: length
>    at System.String.Substring(Int32 startIndex, Int32 length)
>    at Minsk.CodeAnalysis.Text.SourceText.ToString(Int32 start, Int32 length)
>    at Minsk.CodeAnalysis.Text.SourceText.ToString(TextSpan span)
>    at Minsk.MinskRepl.EvaluateSubmission(String text)
>    at Minsk.Repl.Run()
>    at Minsk.Program.Main()
>

The issue is that when the repl tries to print the line where the diagnostic happens, it uses the latest submission, instead of the `SourceText` of the function.

The fix adds a `SourceText` argument everywhere, up to the `Diagnostic`. I guess in a multi-file compilation, diagnostics should know where they came from anyway.