### PR TITLE
Some cleanup

### DIFF
--- a/src/Minsk.Tests/Minsk.Tests.csproj
+++ b/src/Minsk.Tests/Minsk.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -580,20 +580,20 @@ namespace Minsk.CodeAnalysis.Binding
             return variable;
         }
 
-        private VariableSymbol BindVariableReference(SyntaxToken IdentifierToken)
+        private VariableSymbol BindVariableReference(SyntaxToken identifierToken)
         {
-            var name = IdentifierToken.Text;
+            var name = identifierToken.Text;
             switch (_scope.TryLookupSymbol(name))
             {
                 case VariableSymbol variable:
                     return variable;
 
                 case null:
-                    _diagnostics.ReportUndefinedVariable(IdentifierToken.Location, name);
+                    _diagnostics.ReportUndefinedVariable(identifierToken.Location, name);
                     return null;
 
                 default:
-                    _diagnostics.ReportNotAVariable(IdentifierToken.Location, name);
+                    _diagnostics.ReportNotAVariable(identifierToken.Location, name);
                     return null;
             }
         }

--- a/src/Minsk/IO/TextWriterExtensions.cs
+++ b/src/Minsk/IO/TextWriterExtensions.cs
@@ -11,12 +11,15 @@ namespace Minsk.IO
 {
     public static class TextWriterExtensions
     {
-        private static bool IsConsoleOut(this TextWriter writer)
+        private static bool IsConsole(this TextWriter writer)
         {
             if (writer == Console.Out)
-                return true;
+                return !Console.IsOutputRedirected;
 
-            if (writer is IndentedTextWriter iw && iw.InnerWriter.IsConsoleOut())
+            if (writer == Console.Error)
+                return !Console.IsErrorRedirected && !Console.IsOutputRedirected; // Color codes are always output to Console.Out
+
+            if (writer is IndentedTextWriter iw && iw.InnerWriter.IsConsole())
                 return true;
 
             return false;
@@ -24,13 +27,13 @@ namespace Minsk.IO
 
         private static void SetForeground(this TextWriter writer, ConsoleColor color)
         {
-            if (writer.IsConsoleOut())
+            if (writer.IsConsole())
                 Console.ForegroundColor = color;
         }
 
         private static void ResetColor(this TextWriter writer)
         {
-            if (writer.IsConsoleOut())
+            if (writer.IsConsole())
                 Console.ResetColor();
         }
 

--- a/src/Minsk/IO/TextWriterExtensions.cs
+++ b/src/Minsk/IO/TextWriterExtensions.cs
@@ -101,12 +101,12 @@ namespace Minsk.IO
                 var lineIndex = text.GetLineIndex(span.Start);
                 var line = text.Lines[lineIndex];
 
-                Console.WriteLine();
+                writer.WriteLine();
 
-                Console.ForegroundColor = ConsoleColor.DarkRed;
-                Console.Write($"{fileName}({startLine},{startCharacter},{endLine},{endCharacter}): ");
-                Console.WriteLine(diagnostic);
-                Console.ResetColor();
+                writer.SetForeground(ConsoleColor.DarkRed);
+                writer.Write($"{fileName}({startLine},{startCharacter},{endLine},{endCharacter}): ");
+                writer.WriteLine(diagnostic);
+                writer.ResetColor();
 
                 var prefixSpan = TextSpan.FromBounds(line.Start, span.Start);
                 var suffixSpan = TextSpan.FromBounds(span.End, line.End);
@@ -115,19 +115,19 @@ namespace Minsk.IO
                 var error = text.ToString(span);
                 var suffix = text.ToString(suffixSpan);
 
-                Console.Write("    ");
-                Console.Write(prefix);
+                writer.Write("    ");
+                writer.Write(prefix);
 
-                Console.ForegroundColor = ConsoleColor.DarkRed;
-                Console.Write(error);
-                Console.ResetColor();
+                writer.SetForeground(ConsoleColor.DarkRed);
+                writer.Write(error);
+                writer.ResetColor();
 
-                Console.Write(suffix);
+                writer.Write(suffix);
 
-                Console.WriteLine();
+                writer.WriteLine();
             }
 
-            Console.WriteLine();
+            writer.WriteLine();
         }
     }
 }

--- a/src/mc/Program.cs
+++ b/src/mc/Program.cs
@@ -11,12 +11,12 @@ namespace Minsk
 {
     internal static class Program
     {
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
             if (args.Length == 0)
             {
                 Console.Error.WriteLine("usage: mc <source-paths>");
-                return;
+                return 1;
             }
 
             var paths = GetFilePaths(args);
@@ -27,7 +27,7 @@ namespace Minsk
             {
                 if (!File.Exists(path))
                 {
-                    Console.WriteLine($"error: file '{path}' doesn't exist");
+                    Console.Error.WriteLine($"error: file '{path}' doesn't exist");
                     hasErrors = true;
                     continue;
                 }
@@ -36,7 +36,7 @@ namespace Minsk
             }
 
             if (hasErrors)
-                return;
+                return 1;
 
             var compilation = new Compilation(syntaxTrees.ToArray());
             var result = compilation.Evaluate(new Dictionary<VariableSymbol, object>());
@@ -49,7 +49,10 @@ namespace Minsk
             else
             {
                 Console.Error.WriteDiagnostics(result.Diagnostics);
+                return 1;
             }
+
+            return 0;
         }
 
         private static IEnumerable<string> GetFilePaths(IEnumerable<string> paths)


### PR DESCRIPTION
This fixes some minor stuff I noticed after watching episode 15. The changes are self-explanatory.

The one less obvious thing is that `Console.ForegroundColor` always sends color codes to `Console.Out`, so when trying to write colored text to `Console.Error`, I first make sure that both `Console.Out` and `Console.Error` are not redirected.
