### PR TITLE
Minor fixes to Meta commands

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -9,6 +9,8 @@ using Minsk.CodeAnalysis.Lowering;
 using Minsk.CodeAnalysis.Symbols;
 using Minsk.CodeAnalysis.Syntax;
 
+using ReflectionBindingFlags = System.Reflection.BindingFlags;
+
 namespace Minsk.CodeAnalysis
 {
     public sealed class Compilation
@@ -52,6 +54,19 @@ namespace Minsk.CodeAnalysis
 
             while (submission != null)
             {
+                const ReflectionBindingFlags bindingFlags = 
+                    ReflectionBindingFlags.Static |
+                    ReflectionBindingFlags.Public |
+                    ReflectionBindingFlags.NonPublic;
+                var builtinFunctions = typeof(BuiltinFunctions)
+                    .GetFields(bindingFlags)
+                    .Where(fi => fi.FieldType == typeof(FunctionSymbol))
+                    .Select(fi => (FunctionSymbol)fi.GetValue(obj: null))
+                    .ToList();
+                foreach (var builtin in builtinFunctions)
+                    if (seenSymbolNames.Add(builtin.Name))
+                        yield return builtin;
+
                 foreach (var function in submission.Functions)
                     if (seenSymbolNames.Add(function.Name))
                         yield return function;

--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -137,11 +137,10 @@ namespace Minsk.CodeAnalysis
         public void EmitTree(FunctionSymbol symbol, TextWriter writer)
         {
             var program = Binder.BindProgram(GlobalScope);
-            if (!program.Functions.TryGetValue(symbol, out var body))
-                return;
-
             symbol.WriteTo(writer);
             writer.WriteLine();
+            if (!program.Functions.TryGetValue(symbol, out var body))
+                return;
             body.WriteTo(writer);
         }
     }

--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -12,6 +12,8 @@ namespace Minsk
     internal sealed class MinskRepl : Repl
     {
         private static bool _loadingSubmission;
+        private static readonly Compilation emptyCompilation = new Compilation();
+
         private Compilation _previous;
         private bool _showTree;
         private bool _showProgram;
@@ -97,7 +99,7 @@ namespace Minsk
         [MetaCommand("ls", "Lists all symbols")]
         private void EvaluateLs()
         {
-            var compilation = _previous ?? new Compilation();
+            var compilation = _previous ?? emptyCompilation;
             var symbols = compilation.GetSymbols().OrderBy(s => s.Kind).ThenBy(s => s.Name);
             foreach (var symbol in symbols)
             {
@@ -109,7 +111,7 @@ namespace Minsk
         [MetaCommand("dump", "Shows bound tree of a given function")]
         private void EvaluateDump(string functionName)
         {
-            var compilation = _previous ?? new Compilation();
+            var compilation = _previous ?? emptyCompilation;
             var symbol = compilation.GetSymbols().OfType<FunctionSymbol>().SingleOrDefault(f => f.Name == functionName);
             if (symbol == null)
             {

--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -97,10 +97,8 @@ namespace Minsk
         [MetaCommand("ls", "Lists all symbols")]
         private void EvaluateLs()
         {
-            if (_previous == null)
-                return;
-
-            var symbols = _previous.GetSymbols().OrderBy(s => s.Kind).ThenBy(s => s.Name);
+            var compilation = _previous ?? new Compilation();
+            var symbols = compilation.GetSymbols().OrderBy(s => s.Kind).ThenBy(s => s.Name);
             foreach (var symbol in symbols)
             {
                 symbol.WriteTo(Console.Out);
@@ -111,10 +109,8 @@ namespace Minsk
         [MetaCommand("dump", "Shows bound tree of a given function")]
         private void EvaluateDump(string functionName)
         {
-            if (_previous == null)
-                return;
-
-            var symbol = _previous.GetSymbols().OfType<FunctionSymbol>().SingleOrDefault(f => f.Name == functionName);
+            var compilation = _previous ?? new Compilation();
+            var symbol = compilation.GetSymbols().OfType<FunctionSymbol>().SingleOrDefault(f => f.Name == functionName);
             if (symbol == null)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
@@ -123,7 +119,7 @@ namespace Minsk
                 return;
             }
 
-            _previous.EmitTree(symbol, Console.Out);
+            compilation.EmitTree(symbol, Console.Out);
         }
 
         protected override bool IsCompleteSubmission(string text)

--- a/src/msi/Repl.cs
+++ b/src/msi/Repl.cs
@@ -31,7 +31,7 @@ namespace Minsk
                                                BindingFlags.FlattenHierarchy);
             foreach (var method in methods)
             {
-                var attribute = (MetaCommandAttribute)method.GetCustomAttribute(typeof(MetaCommandAttribute));
+                var attribute = method.GetCustomAttribute<MetaCommandAttribute>();
                 if (attribute == null)
                     continue;
 

--- a/src/msi/Repl.cs
+++ b/src/msi/Repl.cs
@@ -483,7 +483,7 @@ namespace Minsk
 
             if (args.Count != parameters.Length)
             {
-                var parameterNames = string.Join(", ", parameters.Select(p => $"<{p.Name}>"));
+                var parameterNames = string.Join(" ", parameters.Select(p => $"<{p.Name}>"));
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine($"error: invalid number of arguments");
                 Console.WriteLine($"usage: #{command.Name} {parameterNames}");

--- a/src/msi/Repl.cs
+++ b/src/msi/Repl.cs
@@ -491,7 +491,8 @@ namespace Minsk
                 return;
             }
 
-            command.Method.Invoke(this, args.ToArray());
+            var instance = command.Method.IsStatic ? null : this;
+            command.Method.Invoke(instance, args.ToArray());
         }
 
         protected abstract bool IsCompleteSubmission(string text);


### PR DESCRIPTION
*Based on Episode 16 PR #83.*

Fixes to Meta command handling

* Use generic `GetCustomAttribute` method for meta command detection
* Meta commands work on both static and instance methods
* Change error message for meta command usage to reflect how the command is actually invoked (remove comma)
  - Before: `command <arg1>, <arg2>`
  - After: `command <arg1> <arg2>`
* `Compilation.GetSymbols` method also yields built-in functions
* `#ls` and `#dump` commands work with the built-in symbols even if the submission history is empty (by using an empty compilation)

`#ls` now shows the following:
```
» #ls
function input(): string
function print(text: string)
function rnd(max: int): int
```

Dumping a built-in function writes only its signature (as there is no body to dump):
```
» #dump print
function print(text: string)
```