### PR TITLE
Make _loadingSubmissions a instance field

### DIFF
--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -11,7 +11,7 @@ namespace Minsk
 {
     internal sealed class MinskRepl : Repl
     {
-        private static bool _loadingSubmission;
+        private bool _loadingSubmission;
         private Compilation _previous;
         private bool _showTree;
         private bool _showProgram;
@@ -219,7 +219,7 @@ namespace Minsk
             Directory.Delete(GetSubmissionsDirectory(), recursive: true);
         }
 
-        private static void SaveSubmission(string text)
+        private void SaveSubmission(string text)
         {
             if (_loadingSubmission)
                 return;


### PR DESCRIPTION
The field `_loadingSubmissions` is assigned from the non-static method `LoadSubmissions`.