### PR TITLE
Add single-line comments

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -87,9 +87,122 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
             Assert.Equal(t2Text, tokens[1].Text);
         }
 
+        [Fact]
+        public void Lexer_Covers_AllTrivia()
+        {
+            var triviaKinds = Enum.GetValues(typeof(SyntaxKind))
+                                  .Cast<SyntaxKind>()
+                                  .Where(k => k.ToString().EndsWith("Trivia"));
+
+            var testedTriviaKinds = GetTrivia().Select(t => t.kind);
+
+            var untestedTriviaKinds = new SortedSet<SyntaxKind>(triviaKinds);
+            untestedTriviaKinds.ExceptWith(testedTriviaKinds);
+
+            Assert.Empty(untestedTriviaKinds);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTriviaData))]
+        public void Lexer_Lexes_TrailingTrivia(SyntaxKind kind, string text)
+        {
+            var tokens = SyntaxTree.ParseTokens("tokenWithTrailingTrivia" + text);
+
+            var token = Assert.Single(tokens);
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+            Assert.Empty(token.LeadingTrivia);
+            var trivia = Assert.Single(token.TrailingTrivia);
+            Assert.Equal(kind, trivia.Kind);
+            Assert.Equal(text, trivia.Text);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTriviaData))]
+        public void Lexer_Lexes_LeadingTrivia(SyntaxKind kind, string text)
+        {
+            if (kind == SyntaxKind.SingleLineCommentTrivia)
+                return;
+
+            var tokens = SyntaxTree.ParseTokens(text + "tokenWithLeadingTrivia");
+
+            var token = Assert.Single(tokens);
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+            var trivia = Assert.Single(token.LeadingTrivia);
+            Assert.Equal(kind, trivia.Kind);
+            Assert.Equal(text, trivia.Text);
+            Assert.Empty(token.TrailingTrivia);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTriviaData))]
+        public void Lexer_Lexes_EndOfFileLeadingTrivia(SyntaxKind kind, string text)
+        {
+            var tokens = SyntaxTree.ParseTokens(text, includeEndOfFile: true);
+
+            var token = Assert.Single(tokens);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind);
+            var trivia = Assert.Single(token.LeadingTrivia);
+            Assert.Empty(token.TrailingTrivia);
+            Assert.Equal(kind, trivia.Kind);
+            Assert.Equal(text, trivia.Text);
+            Assert.Empty(token.TrailingTrivia);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTriviaLineEndingPairsData))]
+        public void Lexer_Lexes_LeadingTriviaFromPreviousLine(SyntaxKind kind, string text, string eolText)
+        {
+            var tokens = SyntaxTree.ParseTokens(text + eolText + "tokenWithLeadingTrivia");
+
+            var token = Assert.Single(tokens);
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+            Assert.Collection(token.LeadingTrivia,
+                trivia =>
+                {
+                    Assert.Equal(kind, trivia.Kind);
+                    Assert.Equal(text, trivia.Text);
+                },
+                eolTrivia =>
+                {
+                    Assert.Equal(SyntaxKind.EndOfLineTrivia, eolTrivia.Kind);
+                    Assert.Equal(eolText, eolTrivia.Text);
+                }
+            );
+            Assert.Empty(token.TrailingTrivia);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTriviaLineEndingPairsData))]
+        public void Lexer_Lexes_EndOfFileLeadingTriviaFromPreviousLine(SyntaxKind kind, string text, string eolText)
+        {
+            var tokens = SyntaxTree.ParseTokens(text + eolText, includeEndOfFile: true);
+
+            var token = Assert.Single(tokens);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind);
+            Assert.Collection(token.LeadingTrivia,
+                trivia =>
+                {
+                    Assert.Equal(kind, trivia.Kind);
+                    Assert.Equal(text, trivia.Text);
+                },
+                eolTrivia =>
+                {
+                    Assert.Equal(SyntaxKind.EndOfLineTrivia, eolTrivia.Kind);
+                    Assert.Equal(eolText, eolTrivia.Text);
+                }
+            );
+            Assert.Empty(token.TrailingTrivia);
+        }
+
         public static IEnumerable<object[]> GetTokensData()
         {
             foreach (var t in GetTokens())
+                yield return new object[] { t.kind, t.text };
+        }
+
+        public static IEnumerable<object[]> GetTriviaData()
+        {
+            foreach (var t in GetTrivia())
                 yield return new object[] { t.kind, t.text };
         }
 
@@ -103,6 +216,12 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
         {
             foreach (var t in GetTokenPairsWithSeparator())
                 yield return new object[] { t.t1Kind, t.t1Text, t.separatorKind, t.separatorText, t.t2Kind, t.t2Text };
+        }
+
+        public static IEnumerable<object[]> GetTriviaLineEndingPairsData()
+        {
+            foreach (var t in GetTriviaLineEndingPairs())
+                yield return new object[] { t.kind, t.text, t.eolText};
         }
 
         private static IEnumerable<(SyntaxKind kind, string text)> GetTokens()
@@ -126,16 +245,38 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
             return fixedTokens.Concat(dynamicTokens);
         }
 
-        private static IEnumerable<(SyntaxKind kind, string text)> GetSeparators()
+        private static IEnumerable<(SyntaxKind kind, string text)> GetLineEndings()
         {
             return new[]
             {
-                (SyntaxKind.WhitespaceTrivia, " "),
-                (SyntaxKind.WhitespaceTrivia, "  "),
                 (SyntaxKind.EndOfLineTrivia, "\r"),
                 (SyntaxKind.EndOfLineTrivia, "\n"),
                 (SyntaxKind.EndOfLineTrivia, "\r\n")
             };
+        }
+
+        private static IEnumerable<(SyntaxKind kind, string text)> GetSeparators()
+        {
+            var seperators = new[]
+            {
+                (SyntaxKind.WhitespaceTrivia, " "),
+                (SyntaxKind.WhitespaceTrivia, "  "),
+            };
+
+            return seperators.Concat(GetLineEndings());
+        }
+
+        private static IEnumerable<(SyntaxKind kind, string text)> GetTrivia()
+        {
+            var trivia = new[]
+            {
+                (SyntaxKind.SingleLineCommentTrivia, "//"),
+                (SyntaxKind.SingleLineCommentTrivia, "// "),
+                (SyntaxKind.SingleLineCommentTrivia, "//a"),
+                (SyntaxKind.SingleLineCommentTrivia, "///"),
+            };
+
+            return trivia.Concat(GetSeparators());
         }
 
         private static bool RequiresSeparator(SyntaxKind t1Kind, SyntaxKind t2Kind)
@@ -228,6 +369,18 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
                         foreach (var s in GetSeparators())
                             yield return (t1.kind, t1.text, s.kind, s.text, t2.kind, t2.text);
                     }
+                }
+            }
+        }
+
+        private static IEnumerable<(SyntaxKind kind, string text, string eolText)> GetTriviaLineEndingPairs()
+        {
+            foreach (var trivia in GetTrivia())
+            {
+                foreach (var lineEnding in GetLineEndings())
+                {
+                    if (trivia.kind != SyntaxKind.EndOfLineTrivia)
+                        yield return (trivia.kind, trivia.text, lineEnding.text);
                 }
             }
         }

--- a/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -32,7 +32,7 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
                                  .Where(k => k.ToString().EndsWith("Keyword") ||
                                              k.ToString().EndsWith("Token"));
 
-            var testedTokenKinds = GetTokens().Concat(GetSeparators()).Select(t => t.kind);
+            var testedTokenKinds = GetTokens().Select(t => t.kind);
 
             var untestedTokenKinds = new SortedSet<SyntaxKind>(tokenKinds);
             untestedTokenKinds.Remove(SyntaxKind.BadToken);
@@ -77,18 +77,19 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
             var text = t1Text + separatorText + t2Text;
             var tokens = SyntaxTree.ParseTokens(text).ToArray();
 
-            Assert.Equal(3, tokens.Length);
+            Assert.Equal(2, tokens.Length);
             Assert.Equal(t1Kind, tokens[0].Kind);
             Assert.Equal(t1Text, tokens[0].Text);
-            Assert.Equal(separatorKind, tokens[1].Kind);
-            Assert.Equal(separatorText, tokens[1].Text);
-            Assert.Equal(t2Kind, tokens[2].Kind);
-            Assert.Equal(t2Text, tokens[2].Text);
+            var trivia = Assert.Single(tokens[0].TrailingTrivia);
+            Assert.Equal(separatorKind, trivia.Kind);
+            Assert.Equal(separatorText, trivia.Text);
+            Assert.Equal(t2Kind, tokens[1].Kind);
+            Assert.Equal(t2Text, tokens[1].Text);
         }
 
         public static IEnumerable<object[]> GetTokensData()
         {
-            foreach (var t in GetTokens().Concat(GetSeparators()))
+            foreach (var t in GetTokens())
                 yield return new object[] { t.kind, t.text };
         }
 
@@ -129,11 +130,11 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
         {
             return new[]
             {
-                (SyntaxKind.WhitespaceToken, " "),
-                (SyntaxKind.WhitespaceToken, "  "),
-                (SyntaxKind.WhitespaceToken, "\r"),
-                (SyntaxKind.WhitespaceToken, "\n"),
-                (SyntaxKind.WhitespaceToken, "\r\n")
+                (SyntaxKind.WhitespaceTrivia, " "),
+                (SyntaxKind.WhitespaceTrivia, "  "),
+                (SyntaxKind.EndOfLineTrivia, "\r"),
+                (SyntaxKind.EndOfLineTrivia, "\n"),
+                (SyntaxKind.EndOfLineTrivia, "\r\n")
             };
         }
 

--- a/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -197,6 +197,9 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
             if (t1Kind == SyntaxKind.PipeToken && t2Kind == SyntaxKind.PipePipeToken)
                 return true;
 
+            if (t1Kind == SyntaxKind.SlashToken && t2Kind == SyntaxKind.SlashToken)
+                return true;
+
             return false;
         }
 

--- a/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
@@ -316,6 +316,9 @@ namespace Minsk.CodeAnalysis.Syntax
                 case '\t':
                     ReadWhiteSpace();
                     break;
+                case '/' when Lookahead == '/':
+                    ReadSingleLineComment();
+                    break;
                 default:
                     if (char.IsWhiteSpace(Current))
                     {
@@ -338,6 +341,14 @@ namespace Minsk.CodeAnalysis.Syntax
                 _position++;
 
             _triviaKind = SyntaxKind.WhitespaceTrivia;
+        }
+
+        private void ReadSingleLineComment()
+        {
+            while (Current != '\0' && Current != '\n' && Current != '\r')
+                _position++;
+
+            _triviaKind = SyntaxKind.SingleLineCommentTrivia;
         }
     }
 }

--- a/src/Minsk/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/Parser.cs
@@ -23,8 +23,7 @@ namespace Minsk.CodeAnalysis.Syntax
             {
                 token = lexer.Lex();
 
-                if (token.Kind != SyntaxKind.WhitespaceToken &&
-                    token.Kind != SyntaxKind.BadToken)
+                if (token.Kind != SyntaxKind.BadToken)
                 {
                     tokens.Add(token);
                 }
@@ -62,7 +61,7 @@ namespace Minsk.CodeAnalysis.Syntax
                 return NextToken();
 
             _diagnostics.ReportUnexpectedToken(Current.Location, Current.Kind, kind);
-            return new SyntaxToken(_syntaxTree, kind, Current.Position, null, null);
+            return new SyntaxToken(_syntaxTree, kind, Current.Position, null, null, ImmutableArray<SyntaxTrivia>.Empty, ImmutableArray<SyntaxTrivia>.Empty);
         }
 
         public CompilationUnitSyntax ParseCompilationUnit()

--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -5,6 +5,7 @@ namespace Minsk.CodeAnalysis.Syntax
         // Trivia
         WhitespaceTrivia,
         EndOfLineTrivia,
+        SingleLineCommentTrivia,
 
         // Tokens
         BadToken,

--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -2,10 +2,13 @@ namespace Minsk.CodeAnalysis.Syntax
 {
     public enum SyntaxKind
     {
+        // Trivia
+        WhitespaceTrivia,
+        EndOfLineTrivia,
+
         // Tokens
         BadToken,
         EndOfFileToken,
-        WhitespaceToken,
         NumberToken,
         StringToken,
         PlusToken,

--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxToken.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxToken.cs
@@ -1,16 +1,19 @@
+using System.Collections.Immutable;
 using Minsk.CodeAnalysis.Text;
 
 namespace Minsk.CodeAnalysis.Syntax
 {
     public sealed class SyntaxToken : SyntaxNode
     {
-        public SyntaxToken(SyntaxTree syntaxTree, SyntaxKind kind, int position, string text, object value)
+        public SyntaxToken(SyntaxTree syntaxTree, SyntaxKind kind, int position, string text, object value, ImmutableArray<SyntaxTrivia> leadingTrivia, ImmutableArray<SyntaxTrivia> trailingTrivia)
             : base(syntaxTree)
         {
             Kind = kind;
             Position = position;
             Text = text;
             Value = value;
+            LeadingTrivia = leadingTrivia;
+            TrailingTrivia = trailingTrivia;
         }
 
         public override SyntaxKind Kind { get; }
@@ -18,6 +21,8 @@ namespace Minsk.CodeAnalysis.Syntax
         public string Text { get; }
         public object Value { get; }
         public override TextSpan Span => new TextSpan(Position, Text?.Length ?? 0);
+        public ImmutableArray<SyntaxTrivia> LeadingTrivia { get; }
+        public ImmutableArray<SyntaxTrivia> TrailingTrivia { get; }
 
         /// <summary>
         /// A token is missing if it was inserted by the parser and doesn't appear in source.

--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -50,24 +50,24 @@ namespace Minsk.CodeAnalysis.Syntax
             return new SyntaxTree(text, Parse);
         }
 
-        public static ImmutableArray<SyntaxToken> ParseTokens(string text)
+        public static ImmutableArray<SyntaxToken> ParseTokens(string text, bool includeEndOfFile = false)
         {
             var sourceText = SourceText.From(text);
-            return ParseTokens(sourceText);
+            return ParseTokens(sourceText, includeEndOfFile);
         }
 
-        public static ImmutableArray<SyntaxToken> ParseTokens(string text, out ImmutableArray<Diagnostic> diagnostics)
+        public static ImmutableArray<SyntaxToken> ParseTokens(string text, out ImmutableArray<Diagnostic> diagnostics, bool includeEndOfFile = false)
         {
             var sourceText = SourceText.From(text);
-            return ParseTokens(sourceText, out diagnostics);
+            return ParseTokens(sourceText, out diagnostics, includeEndOfFile);
         }
 
-        public static ImmutableArray<SyntaxToken> ParseTokens(SourceText text)
+        public static ImmutableArray<SyntaxToken> ParseTokens(SourceText text, bool includeEndOfFile = false)
         {
-            return ParseTokens(text, out _);
+            return ParseTokens(text, out _, includeEndOfFile);
         }
 
-        public static ImmutableArray<SyntaxToken> ParseTokens(SourceText text, out ImmutableArray<Diagnostic> diagnostics)
+        public static ImmutableArray<SyntaxToken> ParseTokens(SourceText text, out ImmutableArray<Diagnostic> diagnostics, bool includeEndOfFile = false)
         {
             var tokens = new List<SyntaxToken>();
 
@@ -81,6 +81,9 @@ namespace Minsk.CodeAnalysis.Syntax
                     var token = l.Lex();
                     if (token.Kind == SyntaxKind.EndOfFileToken)
                     {
+                        if (includeEndOfFile)
+                            tokens.Add(token);
+
                         root = new CompilationUnitSyntax(st, ImmutableArray<MemberSyntax>.Empty, token);
                         break;
                     }

--- a/src/Minsk/CodeAnalysis/Syntax/SyntaxTrivia.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/SyntaxTrivia.cs
@@ -1,0 +1,14 @@
+namespace Minsk.CodeAnalysis.Syntax
+{
+    public sealed class SyntaxTrivia
+    {
+        public SyntaxTrivia(SyntaxKind kind, string text)
+        {
+            Kind = kind;
+            Text = text;
+        }
+
+        public SyntaxKind Kind { get; }
+        public string Text { get; }
+    }
+}

--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -27,6 +27,9 @@ namespace Minsk
             var tokens = SyntaxTree.ParseTokens(line);
             foreach (var token in tokens)
             {
+                foreach (var trivia in token.LeadingTrivia)
+                    Console.Write(trivia.Text);
+
                 var isKeyword = token.Kind.ToString().EndsWith("Keyword");
                 var isIdentifier = token.Kind == SyntaxKind.IdentifierToken;
                 var isNumber = token.Kind == SyntaxKind.NumberToken;
@@ -46,6 +49,9 @@ namespace Minsk
                 Console.Write(token.Text);
 
                 Console.ResetColor();
+
+                foreach (var trivia in token.TrailingTrivia)
+                    Console.Write(trivia.Text);
             }
         }
 

--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -148,7 +148,8 @@ namespace Minsk
             var syntaxTree = SyntaxTree.Parse(text);
 
             // Use Members because we need to exclude the EndOfFileToken.
-            if (syntaxTree.Root.Members.Last().GetLastToken().IsMissing)
+            var members = syntaxTree.Root.Members;
+            if (members.Length == 0 || members.Last().GetLastToken().IsMissing)
                 return false;
 
             return true;

--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -24,34 +24,39 @@ namespace Minsk
 
         protected override void RenderLine(string line)
         {
-            var tokens = SyntaxTree.ParseTokens(line);
+            var tokens = SyntaxTree.ParseTokens(line, includeEndOfFile: true);
             foreach (var token in tokens)
             {
+                Console.ForegroundColor = ConsoleColor.DarkGreen;
                 foreach (var trivia in token.LeadingTrivia)
                     Console.Write(trivia.Text);
 
-                var isKeyword = token.Kind.ToString().EndsWith("Keyword");
-                var isIdentifier = token.Kind == SyntaxKind.IdentifierToken;
-                var isNumber = token.Kind == SyntaxKind.NumberToken;
-                var isString = token.Kind == SyntaxKind.StringToken;
+                if (token.Kind != SyntaxKind.EndOfFileToken)
+                {
+                    var isKeyword = token.Kind.ToString().EndsWith("Keyword");
+                    var isIdentifier = token.Kind == SyntaxKind.IdentifierToken;
+                    var isNumber = token.Kind == SyntaxKind.NumberToken;
+                    var isString = token.Kind == SyntaxKind.StringToken;
 
-                if (isKeyword)
-                    Console.ForegroundColor = ConsoleColor.Blue;
-                else if (isIdentifier)
-                    Console.ForegroundColor = ConsoleColor.DarkYellow;
-                else if (isNumber)
-                    Console.ForegroundColor = ConsoleColor.Cyan;
-                else if (isString)
-                    Console.ForegroundColor = ConsoleColor.Magenta;
-                else
-                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    if (isKeyword)
+                        Console.ForegroundColor = ConsoleColor.Blue;
+                    else if (isIdentifier)
+                        Console.ForegroundColor = ConsoleColor.DarkYellow;
+                    else if (isNumber)
+                        Console.ForegroundColor = ConsoleColor.Cyan;
+                    else if (isString)
+                        Console.ForegroundColor = ConsoleColor.Magenta;
+                    else
+                        Console.ForegroundColor = ConsoleColor.DarkGray;
 
-                Console.Write(token.Text);
+                    Console.Write(token.Text);
+
+                    Console.ForegroundColor = ConsoleColor.DarkGreen;
+                    foreach (var trivia in token.TrailingTrivia)
+                        Console.Write(trivia.Text);
+                }
 
                 Console.ResetColor();
-
-                foreach (var trivia in token.TrailingTrivia)
-                    Console.Write(trivia.Text);
             }
         }
 


### PR DESCRIPTION
Based on your answer on #79 I thought i would give it a try, at least single-line comments for now.

![SingleLineComments](https://user-images.githubusercontent.com/393493/78594246-388d8a80-7848-11ea-9ae7-aadf880baeff.png)

This PR implements single-line comments which are saved as `SingeLineCommentTriva` in the `SyntaxTokens`. `WhitespaceToken` got changed to `WhitespaceTrivia` and `EndOfLineTrivia` as well.

I choose `//` for the syntax, because I was interested how this interacts with the `SlashToken`.

Multiline comments themself are not that hard, but it needs some changes to the way the REPL handles syntax coloring (each line is parsed separately). I have tried something, but that's not yet ready for a pull request. 😅

Thanks a lot for this series. 👍

PS: No worries if you don't merge this, I know it might not fit with your roadmap.