### PR TITLE
Fix GetSymbols for shadowed built-ins

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -63,10 +63,7 @@ namespace Minsk.CodeAnalysis
                     .Where(fi => fi.FieldType == typeof(FunctionSymbol))
                     .Select(fi => (FunctionSymbol)fi.GetValue(obj: null))
                     .ToList();
-                foreach (var builtin in builtinFunctions)
-                    if (seenSymbolNames.Add(builtin.Name))
-                        yield return builtin;
-
+                
                 foreach (var function in submission.Functions)
                     if (seenSymbolNames.Add(function.Name))
                         yield return function;
@@ -74,6 +71,10 @@ namespace Minsk.CodeAnalysis
                 foreach (var variable in submission.Variables)
                     if (seenSymbolNames.Add(variable.Name))
                         yield return variable;
+
+                foreach (var builtin in builtinFunctions)
+                    if (seenSymbolNames.Add(builtin.Name))
+                        yield return builtin;
 
                 submission = submission.Previous;
             }


### PR DESCRIPTION
If a submission re-defines a built-in, the `GetSymbols` method (used by the `#ls` meta-command) will fetch the built-in symbols before the redefinition. This results in `#ls` displaying the wrong symbol (because the binder will first do the submitted symbols)

fixes a bug in previously merged PR #84 