### PR TITLE
Fix null reference exception

### DIFF
--- a/src/Minsk/CodeAnalysis/Binding/Binder.cs
+++ b/src/Minsk/CodeAnalysis/Binding/Binder.cs
@@ -431,7 +431,7 @@ namespace Minsk.CodeAnalysis.Binding
                 else if (expression != null)
                 {
                     // Main does not support return values.
-                    _diagnostics.ReportInvalidReturnExpression(syntax.Expression.Location, _function.Name);
+                    _diagnostics.ReportInvalidReturnWithValueInGlobalStatements(syntax.Expression.Location);
                 }
             }
             else

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -152,6 +152,12 @@ namespace Minsk.CodeAnalysis
             Report(location, message);
         }
 
+        public void ReportInvalidReturnWithValueInGlobalStatements(TextLocation location)
+        {
+            var message = "The 'return' keyword cannot be followed by an expression in global statements.";
+            Report(location, message);
+        }
+
         public void ReportMissingReturnExpression(TextLocation location, TypeSymbol returnType)
         {
             var message = $"An expression of type '{returnType}' is expected.";


### PR DESCRIPTION
`_function` is always null in that case. This also changes the error message since we're not in a function.