### PR TITLE
Support explicit Exit MetaCommand in REPL

### DIFF
--- a/src/msi/MinskRepl.cs
+++ b/src/msi/MinskRepl.cs
@@ -49,6 +49,12 @@ namespace Minsk
             }
         }
 
+        [MetaCommand("exit", "Exits the REPL")]
+        private void EvaluateExit()
+        {
+            Environment.Exit(0);
+        }
+
         [MetaCommand("cls", "Clears the screen")]
         private void EvaluateCls()
         {

--- a/src/msi/Repl.cs
+++ b/src/msi/Repl.cs
@@ -46,7 +46,7 @@ namespace Minsk
             {
                 var text = EditSubmission();
                 if (string.IsNullOrEmpty(text))
-                    return;
+                    continue;
 
                 if (!text.Contains(Environment.NewLine) && text.StartsWith("#"))
                     EvaluateMetaCommand(text);


### PR DESCRIPTION
Instead of exiting the `msi` by newline, we exit through `#exit` meta command in REPL