### PR TITLE
Add some Compiler tests

### DIFF
--- a/src/Minsk.Tests/Compiler/BuildErrorProjectTests.cs
+++ b/src/Minsk.Tests/Compiler/BuildErrorProjectTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace Minsk.Tests.Compiler
+{
+    public class BuildErrorProjectTests : ProjectTestsBase
+    {
+        [Fact]
+        public void EmptyDeclaration()
+        {
+            var (buildSucceeded, buildOutput) = BuildTestProject("error_emptydeclaration");
+            Assert.False(buildSucceeded);
+
+            Assert.Contains(" Unexpected token <CloseBraceToken>, expected <IdentifierToken>", buildOutput);
+        }
+        
+        [Fact]
+        public void UnterminatedString()
+        {
+            var (buildSucceeded, buildOutput) = BuildTestProject("error_unterminatedstring");
+            Assert.False(buildSucceeded);
+
+            Assert.Contains("Unterminated string literal", buildOutput);
+        }
+    }
+}

--- a/src/Minsk.Tests/Compiler/HelloProjectTests.cs
+++ b/src/Minsk.Tests/Compiler/HelloProjectTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace Minsk.Tests.Compiler
+{
+
+    public class HelloProjectTests : ProjectTestsBase
+    {
+        [Fact]
+        public void AsksForName()
+        {           
+            using var helloProcess = RunTestProject("hello");
+
+            Assert.Equal("What's you name?", helloProcess.StandardOutput.ReadLine());
+            helloProcess.StandardInput.WriteLine("Immo");
+            Assert.Equal("Hello Immo!", helloProcess.StandardOutput.ReadLine());
+        }
+    }
+
+}

--- a/src/Minsk.Tests/Compiler/IntsProjectTests.cs
+++ b/src/Minsk.Tests/Compiler/IntsProjectTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace Minsk.Tests.Compiler
+{
+    public class IntsProjectTests : ProjectTestsBase
+    {
+        [Fact]
+        public void Arithmetic()
+        {
+
+            var expectedOutput = new List<string>
+            {
+                "1 + 2 =",
+                "3",
+                "1 * 2 =",
+                "2",
+                "1 - 2 =",
+                "-1",
+                "1 / 2 =",
+                "0",
+                "1 + 1 * 2 =",
+                "3",
+                "(1 + 1) * 2 =",
+                "4",
+            };
+            
+            using var intProcess = RunTestProject("ints");
+
+            foreach (var line in expectedOutput)
+            {
+                Assert.Equal(line, intProcess.StandardOutput.ReadLine());
+            }
+        }
+    }
+
+}

--- a/src/Minsk.Tests/Compiler/ProjectTestsBase.cs
+++ b/src/Minsk.Tests/Compiler/ProjectTestsBase.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using Xunit;
+
+namespace Minsk.Tests.Compiler
+{
+    public abstract class ProjectTestsBase
+    {
+        private string _testProjectsPath = @"../../../Compiler/TestProjects";
+
+        /// <summary>
+        /// Execute dotnet build on the named TestProject
+        /// </summary>
+        /// <param name="project">The name of the folder and msproj</param>
+        /// <param name="configuration">Defaults to Debug</param>
+        protected (bool succeeded, string buildOutput) BuildTestProject(string project, string configuration = "Debug")
+        {
+            var projectPath = GetMinskProjectPath(project);
+
+            using var buildProcess = new Process
+            {
+                StartInfo =
+                {
+                    FileName = "dotnet",
+                    Arguments = $"build {projectPath} -c {configuration}",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                }
+            };
+
+
+            buildProcess.Start();
+            buildProcess.WaitForExit();
+
+            var succeeded = buildProcess.ExitCode == 0;
+            var buildOutput = buildProcess.StandardOutput.ReadToEnd();
+
+            return (succeeded, buildOutput);
+
+        }
+
+        /// <summary>
+        /// Builds the project and starts the generated executable with redirected input/output
+        /// </summary>
+        /// <param name="project">The name of the folder and msproj</param>
+        /// <param name="configuration">Defaults to Debug</param>
+        protected Process RunTestProject(string project, string configuration = "Debug")
+        {
+            var (buildSucceeded, buildOutput) = BuildTestProject(project);
+            Assert.True(buildSucceeded, buildOutput);
+
+            var executablePath = GetExecutablePath(project, configuration);
+
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = executablePath,
+                    UseShellExecute = false,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true
+                }
+            };
+
+
+            process.Start();
+            return process;
+        }
+
+        private string GetMinskProjectPath(string project)
+        {
+            var path = $@"{_testProjectsPath}/{project}/{project}.msproj";
+            Assert.True(File.Exists(path), path);
+            return path;
+        }
+
+        private string GetExecutablePath(string project, string configuration)
+        {
+            var path = $@"{_testProjectsPath}/{project}/bin/{configuration}/{project}";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                path += ".exe";
+            }
+            Assert.True(File.Exists(path), path);
+            return path;
+        }
+    }
+}

--- a/src/Minsk.Tests/Compiler/TestProjects/Directory.Build.props
+++ b/src/Minsk.Tests/Compiler/TestProjects/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <DefaultLanguageSourceExtension>.ms</DefaultLanguageSourceExtension>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/Minsk.Tests/Compiler/TestProjects/Directory.Build.targets
+++ b/src/Minsk.Tests/Compiler/TestProjects/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <Target Name="CreateManifestResourceNames" />
+
+  <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)"
+                     Condition="'%(FileName)' != 'System.Runtime' AND
+                                '%(FileName)' != 'System.Console' AND
+                                '%(FileName)' != 'System.Runtime.Extensions'" />
+    </ItemGroup>
+    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\..\..\msc\msc.csproj&quot; -- @(Compile->'&quot;%(Identity)&quot;', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->'/r &quot;%(Identity)&quot;', ' ')"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+</Project>

--- a/src/Minsk.Tests/Compiler/TestProjects/error_emptydeclaration/error_emptydeclaration.ms
+++ b/src/Minsk.Tests/Compiler/TestProjects/error_emptydeclaration/error_emptydeclaration.ms
@@ -1,0 +1,4 @@
+function main()
+{
+    let a =
+}

--- a/src/Minsk.Tests/Compiler/TestProjects/error_emptydeclaration/error_emptydeclaration.msproj
+++ b/src/Minsk.Tests/Compiler/TestProjects/error_emptydeclaration/error_emptydeclaration.msproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Minsk.Tests/Compiler/TestProjects/error_unterminatedstring/error_unterminatedstring.ms
+++ b/src/Minsk.Tests/Compiler/TestProjects/error_unterminatedstring/error_unterminatedstring.ms
@@ -1,0 +1,4 @@
+function main()
+{
+    let a = "abc
+}

--- a/src/Minsk.Tests/Compiler/TestProjects/error_unterminatedstring/error_unterminatedstring.msproj
+++ b/src/Minsk.Tests/Compiler/TestProjects/error_unterminatedstring/error_unterminatedstring.msproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Minsk.Tests/Compiler/TestProjects/hello/hello.ms
+++ b/src/Minsk.Tests/Compiler/TestProjects/hello/hello.ms
@@ -1,0 +1,6 @@
+function main()
+{
+    print("What's you name?")
+    let name = input()
+    print("Hello " + name + "!")
+}

--- a/src/Minsk.Tests/Compiler/TestProjects/hello/hello.msproj
+++ b/src/Minsk.Tests/Compiler/TestProjects/hello/hello.msproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Minsk.Tests/Compiler/TestProjects/ints/ints.ms
+++ b/src/Minsk.Tests/Compiler/TestProjects/ints/ints.ms
@@ -1,0 +1,23 @@
+function main()
+{
+    let one = 1
+    let two = 2
+    
+    print("1 + 2 =")
+    print(string(one + two))
+    
+    print("1 * 2 =")
+    print(string(one * two))
+        
+    print("1 - 2 =")
+    print(string(one - two))
+    
+    print("1 / 2 =")
+    print(string(one / two))
+    
+    print("1 + 1 * 2 =")
+    print(string(one + one * two))
+    
+    print("(1 + 1) * 2 =")
+    print(string((one + one) * two))
+}

--- a/src/Minsk.Tests/Compiler/TestProjects/ints/ints.msproj
+++ b/src/Minsk.Tests/Compiler/TestProjects/ints/ints.msproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Minsk.Tests/Minsk.Tests.csproj
+++ b/src/Minsk.Tests/Minsk.Tests.csproj
@@ -16,5 +16,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Minsk\Minsk.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <!-- Make VS / Rider show the .msproj and hide the bin or obj folders in the TestProjects-->
+    <None Include="Compiler\TestProjects\**" Exclude="**\bin\**;**\obj\**" />
+    <None Remove="Compiler\TestProjects\**\bin\**;Compiler\TestProjects\**\obj\**" />
+  </ItemGroup>
 
 </Project>

--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -143,6 +143,12 @@ namespace Minsk.CodeAnalysis
 
         public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath)
         {
+            var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
+
+            var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
+            if (diagnostics.Any())
+                return diagnostics;
+            
             var program = GetProgram();
             return Emitter.Emit(program, moduleName, references, outputPath);
         }


### PR DESCRIPTION
A solution for adding some end to end tests for compiling and running Minsk projects

1) Adds tests and fixes the compiler not returning diagnostics reported from the parser.
1) Projects which are built by `dotnet build` and run with redirected console input/output
These currently test:
- print() and input() functions
- int operations (+ * - /)
- string conversion and concatenation

This does increase the test run time from ~2s to ~9s on my machine.