### PR TITLE
Moving reflection part out of the loop.

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -61,15 +61,7 @@ namespace Minsk.CodeAnalysis
             var submission = this;
             var seenSymbolNames = new HashSet<string>();
 
-            const ReflectionBindingFlags bindingFlags =
-                ReflectionBindingFlags.Static |
-                ReflectionBindingFlags.Public |
-                ReflectionBindingFlags.NonPublic;
-            var builtinFunctions = typeof(BuiltinFunctions)
-                .GetFields(bindingFlags)
-                .Where(fi => fi.FieldType == typeof(FunctionSymbol))
-                .Select(fi => (FunctionSymbol)fi.GetValue(obj: null))
-                .ToList();
+            var builtinFunctions = BuiltinFunctions.GetAll().ToList();
 
             while (submission != null)
             {

--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -61,18 +61,18 @@ namespace Minsk.CodeAnalysis
             var submission = this;
             var seenSymbolNames = new HashSet<string>();
 
+            const ReflectionBindingFlags bindingFlags =
+                ReflectionBindingFlags.Static |
+                ReflectionBindingFlags.Public |
+                ReflectionBindingFlags.NonPublic;
+            var builtinFunctions = typeof(BuiltinFunctions)
+                .GetFields(bindingFlags)
+                .Where(fi => fi.FieldType == typeof(FunctionSymbol))
+                .Select(fi => (FunctionSymbol)fi.GetValue(obj: null))
+                .ToList();
+
             while (submission != null)
             {
-                const ReflectionBindingFlags bindingFlags =
-                    ReflectionBindingFlags.Static |
-                    ReflectionBindingFlags.Public |
-                    ReflectionBindingFlags.NonPublic;
-                var builtinFunctions = typeof(BuiltinFunctions)
-                    .GetFields(bindingFlags)
-                    .Where(fi => fi.FieldType == typeof(FunctionSymbol))
-                    .Select(fi => (FunctionSymbol)fi.GetValue(obj: null))
-                    .ToList();
-
                 foreach (var function in submission.Functions)
                     if (seenSymbolNames.Add(function.Name))
                         yield return function;


### PR DESCRIPTION
Maybe not a huge performance increase, but the reflection of BuiltInFunctions should be out of the loop because those do not change with each submission. Maybe even the whole `foreach` on the builtinfunction-list should be out of the loop?