### PR TITLE
Return parse diagnostics before emitting

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -135,6 +135,12 @@ namespace Minsk.CodeAnalysis
 
         public ImmutableArray<Diagnostic> Emit(string moduleName, string[] references, string outputPath)
         {
+            var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
+
+            var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
+            if (diagnostics.Any())
+                return diagnostics;
+            
             var program = GetProgram();
             return Emitter.Emit(program, moduleName, references, outputPath);
         }


### PR DESCRIPTION
Matches `Compilation.Evaluate(...)` behaviour.

Otherwise we ignore any parsing errors and try to emit the program anyway.
e.g. This currently compiles to IL and runs
```
function main()
    let greeting = "Hello
    print(greeting)
```