### PR TITLE
Few updates to Build infra

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/msi/bin/Debug/netcoreapp3.1/msi.dll",
+            "program": "${workspaceFolder}/src/msi/bin/Debug/msi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/msi",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,46 +1,222 @@
 {
     "version": "2.0.0",
     "tasks": [
+        // Builds 'minsk.sln' solution with default configurations
         {
             "label": "build",
             "command": "dotnet",
             "type": "process",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
             "args": [
-                "build",
-                "${workspaceFolder}/src/minsk.sln"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "mc",
-            "command": "dotnet",
-            "type": "shell",
-            "args": [
-                "run",
-                "--project",
-                "${workspaceFolder}/src/msc/msc.csproj",
-                "--",
-                "${fileDirname}"
+                "build"
             ],
             "presentation": {
-                "echo": true,
-                "reveal": "always",
                 "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
+                "clear": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // Builds the specified source project as selected by the user
+        {
+            "label": "build-csproj",
+            "command": "dotnet",
+            "type": "process",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
+            "args": [
+                "build",
+                "${input:csproj}"
+            ],
+            "presentation": {
+                "focus": true,
+                "clear": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // Builds 'minsk.sln' solution and runs the test projects in the solution
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
+            "args": [
+                "test"
+            ],
+            "presentation": {
+                "focus": true,
+                "clear": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // Cleans the build outputs of the 'minsk.sln' solution
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "type": "process",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
+            "args": [
+                "clean"
+            ],
+            "presentation": {
+                "focus": true,
+                "clear": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        // Builds the specified sample project as selected by the user
+        {
+            "label": "build-msproj",
+            "command": "dotnet",
+            "type": "process",
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceFolder}/samples"
+            },
+            "args": [
+                "build",
+                "${input:msproj}"
+            ],
+            "presentation": {
+                "focus": true,
                 "clear": true
             },
             "problemMatcher": {
+                "owner": "minsk",
                 "fileLocation": "absolute",
                 "pattern": [
                     {
-                        "regexp": "^(.*)\\((\\d,\\d\\,\\d\\,\\d\\))\\: (.*)$",
+                        "regexp": "^(.+)\\((\\d+,\\d+,\\d+,\\d+)\\):\\s+(.+)$",
                         "file": 1,
                         "location": 2,
                         "message": 3
                     }
                 ]
             }
+        },
+        // Builds and Runs the specified sample project as selected by the user
+        {
+            "label": "run-msproj",
+            "command": "dotnet",
+            "type": "process",
+            "options": {
+                "cwd": "${workspaceFolder}/samples"
+            },
+            "args": [
+                "run",
+                "--project",
+                "${input:msproj}"
+            ],
+            "presentation": {
+                "focus": true,
+                "clear": true
+            },
+            "problemMatcher": {
+                "owner": "minsk",
+                "fileLocation": "absolute",
+                "pattern": [
+                    {
+                        "regexp": "^(.+)\\((\\d+,\\d+,\\d+,\\d+)\\):\\s+(.+)$",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ]
+            }
+        },
+        // Builds and Runs the Minsk compiler with the currently opened file's folder path
+        {
+            "label": "msc",
+            "command": "dotnet",
+            "type": "process",
+            "options": {
+                "cwd": "${workspaceFolder}/samples"
+            },
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/src/msc",
+                "--",
+                "${fileDirname}"
+            ],
+            "presentation": {
+                "focus": true,
+                "clear": true
+            },
+            "problemMatcher": {
+                "owner": "minsk",
+                "fileLocation": "absolute",
+                "pattern": [
+                    {
+                        "regexp": "^(.+)\\((\\d+,\\d+,\\d+,\\d+)\\):\\s+(.+)$",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ]
+            }
+        },
+        // Builds and Runs the Minsk interpreter
+        {
+            "label": "msi",
+            "command": "dotnet",
+            "type": "process",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}/samples"
+            },
+            "args": [
+                "run",
+                "--project",
+                "${workspaceFolder}/src/msi"
+            ],
+            "presentation": {
+                "clear": true,
+                "focus": true
+            },
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        // Inputs for the source projects. Be sure to update the list if you've added new project(s).
+        {
+            "id": "csproj",
+            "type": "pickString",
+            "description": "Pick your Source project",
+            "options": [
+                "msc",
+                "msi",
+                "Minsk",
+                "Minsk.Generators",
+                "Minsk.Tests"
+            ],
+            "default": "msc"
+        },
+        // Inputs for the sample projects. Be sure to update the list if you've added new project(s).
+        {
+            "id": "msproj",
+            "type": "pickString",
+            "description": "Pick your Sample minsk project",
+            "options": [
+                "hello"
+            ],
+            "default": "hello"
         }
     ]
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ variables:
   buildConfiguration: 'Release'
   sln: './src/minsk.sln'
   tests: './src/Minsk.Tests/Minsk.Tests.csproj'
+  samples: './samples/samples.sln'
 
 steps:
 - task: DotNetCoreCLI@2
@@ -22,3 +23,9 @@ steps:
     projects: $(tests)
     arguments: -c $(buildConfiguration)
     publishTestResults: true
+- task: DotNetCoreCLI@2
+  displayName: Build samples ($(buildConfiguration))
+  inputs:
+    command: build
+    projects: $(samples)
+    arguments: -c $(buildConfiguration)

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,10 @@
 @echo off
 
-dotnet build .\src\minsk.sln /nologo
-dotnet test .\src\Minsk.Tests\Minsk.Tests.csproj
+REM Vars
+set "SLNDIR=%~dp0src"
+
+REM Restore + Build
+dotnet build "%SLNDIR%\minsk.sln" --nologo || exit /b
+
+REM Test
+dotnet test "%SLNDIR%\Minsk.Tests" --nologo --no-build

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-dotnet build ./src/minsk.sln /nologo
-dotnet test ./src/Minsk.Tests/Minsk.Tests.csproj
+# Vars
+slndir="$(dirname "${BASH_SOURCE[0]}")/src"
+
+# Restore + Build
+dotnet build "$slndir/minsk.sln" --nologo || exit
+
+# Test
+dotnet test "$slndir/Minsk.Tests" --nologo --no-build

--- a/msc.cmd
+++ b/msc.cmd
@@ -1,3 +1,10 @@
 @echo off
 
-dotnet run --project .\src\msc\msc.csproj -- "%*"
+REM Vars
+set "SLNDIR=%~dp0src"
+
+REM Restore + Build
+dotnet build "%SLNDIR%\msc" --nologo || exit /b
+
+REM Run
+dotnet run -p "%SLNDIR%\msc" --no-build -- %*

--- a/msc.sh
+++ b/msc.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-dotnet run --project ./src/msc/msc.csproj -- "$@"
+# Vars
+slndir="$(dirname "${BASH_SOURCE[0]}")/src"
+
+# Restore + Build
+dotnet build "$slndir/msc" --nologo || exit
+
+# Run
+dotnet run -p "$slndir/msc" --no-build -- "$@"

--- a/msi.cmd
+++ b/msi.cmd
@@ -1,3 +1,10 @@
 @echo off
 
-dotnet run --project .\src\msi\msi.csproj
+REM Vars
+set "SLNDIR=%~dp0src"
+
+REM Restore + Build
+dotnet build "%SLNDIR%\msi" --nologo || exit /b
+
+REM Run
+dotnet run -p "%SLNDIR%\msi" --no-build

--- a/msi.sh
+++ b/msi.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-dotnet run --project ./src/msi/msi.csproj
+# Vars
+slndir="$(dirname "${BASH_SOURCE[0]}")/src"
+
+# Restore + Build
+dotnet build "$slndir/msi" --nologo || exit
+
+# Run
+dotnet run -p "$slndir/msi" --no-build

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -4,4 +4,13 @@
     <DefaultLanguageSourceExtension>.ms</DefaultLanguageSourceExtension>
   </PropertyGroup>
 
+  <!--
+      Since we're only targeting single framework, we don't need to append
+      the short TFM and RID to the output paths.
+  -->
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -9,8 +9,19 @@
                                 '%(FileName)' != 'System.Runtime' AND
                                 '%(FileName)' != 'System.Runtime.Extensions'" />
     </ItemGroup>
-    <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\msc\msc.csproj&quot; -- @(Compile->'&quot;%(Identity)&quot;', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->'/r &quot;%(Identity)&quot;', ' ')"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
+
+    <PropertyGroup>
+      <MinskCompilerArgs>@(Compile->'"%(Identity)"', ' ')</MinskCompilerArgs>
+      <MinskCompilerArgs>$(MinskCompilerArgs) /o "@(IntermediateAssembly)"</MinskCompilerArgs>
+      <MinskCompilerArgs>$(MinskCompilerArgs) @(ReferencePath->'/r "%(Identity)"', ' ')</MinskCompilerArgs>
+
+      <MinskScriptExt Condition="$([MSBuild]::IsOSUnixLike())">.sh</MinskScriptExt>
+      <MinskScriptExt Condition="$([MSBuild]::IsOSPlatform('Windows'))">.cmd</MinskScriptExt>
+      <MinskCompilerScript Condition="'$(MinskCompilerScript)' == ''">msc$(MinskScriptExt)</MinskCompilerScript>
+      <MinskCompileCommand>"$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\', '$(MinskCompilerScript)'))" $(MinskCompilerArgs)</MinskCompileCommand>
+    </PropertyGroup>
+
+    <Exec Command="$(MinskCompileCommand)" />
   </Target>
 
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -5,8 +5,8 @@
   <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
     <ItemGroup>
       <ReferencePath Remove="@(ReferencePath)"
-                     Condition="'%(FileName)' != 'System.Runtime' AND
-                                '%(FileName)' != 'System.Console' AND
+                     Condition="'%(FileName)' != 'System.Console' AND
+                                '%(FileName)' != 'System.Runtime' AND
                                 '%(FileName)' != 'System.Runtime.Extensions'" />
     </ItemGroup>
     <Exec Command="dotnet run --project &quot;$(MSBuildThisFileDirectory)\..\src\msc\msc.csproj&quot; -- @(Compile->'&quot;%(Identity)&quot;', ' ') /o &quot;@(IntermediateAssembly)&quot; @(ReferencePath->'/r &quot;%(Identity)&quot;', ' ')"

--- a/samples/samples.sln
+++ b/samples/samples.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "hello", "hello\hello.msproj", "{9DB9B226-6BB1-4EA3-ABFF-9F88E50333A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9DB9B226-6BB1-4EA3-ABFF-9F88E50333A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DB9B226-6BB1-4EA3-ABFF-9F88E50333A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DB9B226-6BB1-4EA3-ABFF-9F88E50333A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DB9B226-6BB1-4EA3-ABFF-9F88E50333A6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2D82F985-1252-43DB-BA06-23039810FBE3}
+	EndGlobalSection
+EndGlobal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,25 +1,25 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-    <Features>strict</Features>
+    <Features>Strict</Features>
+    <Nullable>Enable</Nullable>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
 
   <!--
-    HACK
-
-      VS Code currently doesn't support Roslyn generators (VS does, tho). In
-      order to void seeing errors in VS Code and to get IntelliSense, we're
-      doing a trick:
+      HACK:
+      VS Code currently doesn't support Roslyn generators (VS 16.6+ does, tho).
+      In order to void seeing errors in VS Code and to get IntelliSense,
+      we're doing a trick:
 
       1. The generator writes the file to disk, using the *.g.cs naming
          convention (borrowed from WPF).
       2. In MSBuild we're excluding those files
 
-      Since VS Code (or more specifically OmniSharp) doesn't use MSBuild it will
-      still include the file while neither VS nore the CLI/CI build will.
+      Since VS Code's C# extension (or more specifically OmniSharp) doesn't
+      resolve items from MSBuild, it will include the file while neither
+      VS nor the CLI/CI build will.
   -->
-
   <PropertyGroup>
     <GeneratedSources>**/*.g.cs</GeneratedSources>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(GeneratedSources)</DefaultItemExcludes>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,15 @@
   </PropertyGroup>
 
   <!--
+      Since we're only targeting single framework, we don't need to append
+      the short TFM and RID to the output paths.
+  -->
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <!--
       HACK:
       VS Code currently doesn't support Roslyn generators (VS 16.6+ does, tho).
       In order to void seeing errors in VS Code and to get IntelliSense,

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,15 +1,14 @@
 <Project>
 
   <!--
-    HACK
+      HACK:
+      There is an issue in the current preview of .NET 5 SDK where the compiler
+      that was shipped with it doesn't support source generators.
 
-      There is an issue in the current .NET 5 SDK where the compiler that was shipped
-      with it doesn't support source generators. We work this around by specifically
-      depending on a later version of the compiler.
+      We work this around by specifically depending on a later version of the compiler.
   -->
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Compilers" Version="3.6.0-4.final" />
+    <PackageReference Include="Microsoft.NET.Compilers.ToolSet" Version="3.6.0-4.final" />
   </ItemGroup>
 
 </Project>

--- a/src/Minsk.Generators/Minsk.Generators.csproj
+++ b/src/Minsk.Generators/Minsk.Generators.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- TODO: Remove when nullable annotations are added -->
     <Nullable>Disable</Nullable>

--- a/src/Minsk.Generators/Minsk.Generators.csproj
+++ b/src/Minsk.Generators/Minsk.Generators.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- TODO: Remove when nullable annotations are added -->
+    <Nullable>Disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Minsk.Generators/SyntaxNodeGetChildrenGenerator.cs
+++ b/src/Minsk.Generators/SyntaxNodeGetChildrenGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Minsk.Tests/Minsk.Tests.csproj
+++ b/src/Minsk.Tests/Minsk.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- TODO: Remove when nullable annotations are added -->
+    <Nullable>Disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Minsk.Tests/Minsk.Tests.csproj
+++ b/src/Minsk.Tests/Minsk.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Minsk.Tests/Minsk.Tests.csproj
+++ b/src/Minsk.Tests/Minsk.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <!-- TODO: Remove when nullable annotations are added -->
     <Nullable>Disable</Nullable>

--- a/src/Minsk/Minsk.csproj
+++ b/src/Minsk/Minsk.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Minsk/Minsk.csproj
+++ b/src/Minsk/Minsk.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Minsk/Minsk.csproj
+++ b/src/Minsk/Minsk.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/minsk.sln
+++ b/src/minsk.sln
@@ -4,13 +4,13 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk", "Minsk\Minsk.csproj", "{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk.Generators", "Minsk.Generators\Minsk.Generators.csproj", "{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk.Tests", "Minsk.Tests\Minsk.Tests.csproj", "{36E2CC3E-B08D-4B6D-8901-651C800CABAC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "msc", "msc\msc.csproj", "{016A06A3-0FED-42BE-99CA-74FDE1D0D03D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "msi", "msi\msi.csproj", "{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk.Generators", "Minsk.Generators\Minsk.Generators.csproj", "{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,6 +22,10 @@ Global
 		{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{36E2CC3E-B08D-4B6D-8901-651C800CABAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{36E2CC3E-B08D-4B6D-8901-651C800CABAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36E2CC3E-B08D-4B6D-8901-651C800CABAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -34,10 +38,6 @@ Global
 		{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/minsk.sln
+++ b/src/minsk.sln
@@ -2,15 +2,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk", "Minsk\Minsk.csproj", "{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minsk", "Minsk\Minsk.csproj", "{6FE6F7CC-1626-4731-9B68-7236B5A4C94C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk.Generators", "Minsk.Generators\Minsk.Generators.csproj", "{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minsk.Generators", "Minsk.Generators\Minsk.Generators.csproj", "{C106F0D5-AEA3-460F-AA42-B796C6F85B3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minsk.Tests", "Minsk.Tests\Minsk.Tests.csproj", "{36E2CC3E-B08D-4B6D-8901-651C800CABAC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minsk.Tests", "Minsk.Tests\Minsk.Tests.csproj", "{36E2CC3E-B08D-4B6D-8901-651C800CABAC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "msc", "msc\msc.csproj", "{016A06A3-0FED-42BE-99CA-74FDE1D0D03D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "msc", "msc\msc.csproj", "{016A06A3-0FED-42BE-99CA-74FDE1D0D03D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "msi", "msi\msi.csproj", "{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "msi", "msi\msi.csproj", "{9C7AFA59-BB65-46AB-A14B-30F601CBDC8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/msc/msc.csproj
+++ b/src/msc/msc.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/msc/msc.csproj
+++ b/src/msc/msc.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsTool>true</IsTool>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <ProjectName>Minsk</ProjectName>
+    <RootNamespace>Minsk</RootNamespace>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 

--- a/src/msi/msi.csproj
+++ b/src/msi/msi.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/msi/msi.csproj
+++ b/src/msi/msi.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsTool>true</IsTool>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <ProjectName>Minsk</ProjectName>
+    <RootNamespace>Minsk</RootNamespace>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 


### PR DESCRIPTION
These are the updates that I wanted to include it in #106 but it was already a large enough change. 😇

- [x] **Miscellaneous**
Removed BOM from remaining files
Added/Updated Comments where possible
Don't append short TFMs and RIDs to output paths
**Use `Microsoft.NET.Compilers.ToolSet` that contains both CoreCLR and NETCLR compilers** (Fixes #137)

- [x] **Updated scripts and VSCode tasks**
Enable scripts to be invoked from different directory than the script's directory.
Updated tasks to have most used workflows, for those, who hate to go to terminal every time.
Construct compiler command line from properties, so that it's easy to edit and reason about.

- [x] **Update NuGet Packages**
Some are latest versions (xunit packages)
Some are stable versions (immutable collections & test sdk packages)

- [x] **Add Required Project meta**
Not all projects needed to be packed/published. Setting these properties will prevent that.
The `IsTool` and `ProjectName` will be useful when we publish tools into local directory for testing.

- [x] **Updated minsk solution file**
The file registers sdk-style projects as non-sdk style project. Also it had x86/x64 platforms defined.
For now, we're only compiling for `AnyCPU` target which is `MSIL`, which can be loaded by any .NET Core runtime.

- [x] **Build samples in CI**
Add a new Samples solution to build in CI.

**Note**: This is the best I came up with while watching your stream but If there is something you want to do it in a different way, please tell me.