### PR TITLE
Optimize string concatenation

### DIFF
--- a/src/Minsk/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Minsk/CodeAnalysis/Emit/Emitter.cs
@@ -19,7 +19,10 @@ namespace Minsk.CodeAnalysis.Emit
         private readonly MethodReference _objectEqualsReference;
         private readonly MethodReference _consoleReadLineReference;
         private readonly MethodReference _consoleWriteLineReference;
-        private readonly MethodReference _stringConcatReference;
+        private readonly MethodReference _stringConcat2Reference;
+        private readonly MethodReference _stringConcat3Reference;
+        private readonly MethodReference _stringConcat4Reference;
+        private readonly MethodReference _stringConcatArrayReference;
         private readonly MethodReference _convertToBooleanReference;
         private readonly MethodReference _convertToInt32Reference;
         private readonly MethodReference _convertToStringReference;
@@ -145,7 +148,10 @@ namespace Minsk.CodeAnalysis.Emit
             _objectEqualsReference = ResolveMethod("System.Object", "Equals", new [] { "System.Object", "System.Object" });
             _consoleReadLineReference = ResolveMethod("System.Console", "ReadLine", Array.Empty<string>());
             _consoleWriteLineReference = ResolveMethod("System.Console", "WriteLine", new [] { "System.Object" });
-            _stringConcatReference = ResolveMethod("System.String", "Concat", new [] { "System.String", "System.String" });
+            _stringConcat2Reference = ResolveMethod("System.String", "Concat", new [] { "System.String", "System.String" });
+            _stringConcat3Reference = ResolveMethod("System.String", "Concat", new [] { "System.String", "System.String", "System.String" });
+            _stringConcat4Reference = ResolveMethod("System.String", "Concat", new [] { "System.String", "System.String", "System.String", "System.String" });
+            _stringConcatArrayReference = ResolveMethod("System.String", "Concat", new [] { "System.String[]" });
             _convertToBooleanReference = ResolveMethod("System.Convert", "ToBoolean", new [] { "System.Object" });
             _convertToInt32Reference = ResolveMethod("System.Convert", "ToInt32", new [] { "System.Object" });
             _convertToStringReference = ResolveMethod("System.Convert", "ToString", new [] { "System.Object" });
@@ -416,19 +422,19 @@ namespace Minsk.CodeAnalysis.Emit
 
         private void EmitBinaryExpression(ILProcessor ilProcessor, BoundBinaryExpression node)
         {
-            EmitExpression(ilProcessor, node.Left);
-            EmitExpression(ilProcessor, node.Right);
-
             // +(string, string)
 
             if (node.Op.Kind == BoundBinaryOperatorKind.Addition)
             {
                 if (node.Left.Type == TypeSymbol.String && node.Right.Type == TypeSymbol.String)
                 {
-                    ilProcessor.Emit(OpCodes.Call, _stringConcatReference);
+                    EmitStringConcatExpression(ilProcessor, node);
                     return;
                 }
             }
+
+            EmitExpression(ilProcessor, node.Left);
+            EmitExpression(ilProcessor, node.Right);
 
             // ==(any, any)
             // ==(string, string)
@@ -511,6 +517,72 @@ namespace Minsk.CodeAnalysis.Emit
                     break;
                 default:
                     throw new Exception($"Unexpected binary operator {SyntaxFacts.GetText(node.Op.SyntaxKind)}({node.Left.Type}, {node.Right.Type})");
+            }
+        }
+
+        private void EmitStringConcatExpression(ILProcessor ilProcessor, BoundBinaryExpression node)
+        {
+            var nodes = Flatten(node).ToList();
+
+            switch (nodes.Count)
+            {
+                case 2:
+                    EmitExpression(ilProcessor, nodes[0]);
+                    EmitExpression(ilProcessor, nodes[1]);
+                    ilProcessor.Emit(OpCodes.Call, _stringConcat2Reference);
+                    break;
+
+                case 3:
+                    EmitExpression(ilProcessor, nodes[0]);
+                    EmitExpression(ilProcessor, nodes[1]);
+                    EmitExpression(ilProcessor, nodes[2]);
+                    ilProcessor.Emit(OpCodes.Call, _stringConcat3Reference);
+                    break;
+
+                case 4:
+                    EmitExpression(ilProcessor, nodes[0]);
+                    EmitExpression(ilProcessor, nodes[1]);
+                    EmitExpression(ilProcessor, nodes[2]);
+                    EmitExpression(ilProcessor, nodes[3]);
+                    ilProcessor.Emit(OpCodes.Call, _stringConcat4Reference);
+                    break;
+
+                default:
+                    ilProcessor.Emit(OpCodes.Ldc_I4, nodes.Count);
+                    ilProcessor.Emit(OpCodes.Newarr, _knownTypes[TypeSymbol.String]);
+
+                    for (var i = 0; i < nodes.Count; i++)
+                    {
+                        ilProcessor.Emit(OpCodes.Dup);
+                        ilProcessor.Emit(OpCodes.Ldc_I4, i);
+                        EmitExpression(ilProcessor, nodes[i]);
+                        ilProcessor.Emit(OpCodes.Stelem_Ref);
+                    }
+
+                    ilProcessor.Emit(OpCodes.Call, _stringConcatArrayReference);
+                    break;
+            }
+
+            static IEnumerable<BoundExpression> Flatten(BoundExpression node)
+            {
+                if (node is BoundBinaryExpression binaryExpression &&
+                    binaryExpression.Op.Kind == BoundBinaryOperatorKind.Addition &&
+                    binaryExpression.Left.Type == TypeSymbol.String &&
+                    binaryExpression.Right.Type == TypeSymbol.String)
+                {
+                    foreach (var result in Flatten(binaryExpression.Left))
+                        yield return result;
+
+                    foreach (var result in Flatten(binaryExpression.Right))
+                        yield return result;
+                }
+                else
+                {
+                    if (node.Type != TypeSymbol.String)
+                        throw new Exception($"Unexpected node type in string concatenation: {node.Type}");
+
+                    yield return node;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #97.

 - The first commit flattens the expression tree and chooses the most appropriate overload of `String.Concat`
 - The second commit adds constant folding, so that `(a + "foo") + ("bar" + b)` ends up emitting `String.Concat(a, "foobar", b)`

This is based on `episode22`, as it uses constant folding. I did not write unit tests though, since I don't know how you'd like to test the emitter.
