### PR TITLE
Propagate lexer/parser diagnostics through the binder

### DIFF
--- a/src/Minsk/CodeAnalysis/Compilation.cs
+++ b/src/Minsk/CodeAnalysis/Compilation.cs
@@ -89,11 +89,8 @@ namespace Minsk.CodeAnalysis
 
         public EvaluationResult Evaluate(Dictionary<VariableSymbol, object> variables)
         {
-            var parseDiagnostics = SyntaxTrees.SelectMany(st => st.Diagnostics);
-
-            var diagnostics = parseDiagnostics.Concat(GlobalScope.Diagnostics).ToImmutableArray();
-            if (diagnostics.Any())
-                return new EvaluationResult(diagnostics, null);
+            if (GlobalScope.Diagnostics.Any())
+                return new EvaluationResult(GlobalScope.Diagnostics, null);
 
             var program = GetProgram();
 

--- a/src/Minsk/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Minsk/CodeAnalysis/DiagnosticBag.cs
@@ -17,9 +17,9 @@ namespace Minsk.CodeAnalysis
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public void AddRange(DiagnosticBag diagnostics)
+        public void AddRange(IEnumerable<Diagnostic> diagnostics)
         {
-            _diagnostics.AddRange(diagnostics._diagnostics);
+            _diagnostics.AddRange(diagnostics);
         }
 
         private void Report(TextLocation location, string message)


### PR DESCRIPTION
Syntax-related errors were not taken into account when emitting IL, and the compiler would crash on some inputs.

This avoids binding the program when there are syntax errors, and propagates the diagnostics.

This will necessarily require some adjustment if you introduce warnings.