### PR TITLE
Allow digits and underscores in identifiers

### DIFF
--- a/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
+++ b/src/Minsk.Tests/CodeAnalysis/Syntax/LexerTests.cs
@@ -86,6 +86,22 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
             Assert.Equal(t2Text, tokens[2].Text);
         }
 
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("foo42")]
+        [InlineData("foo_42")]
+        [InlineData("_foo")]
+        public void Lexer_Lexes_Identifiers(string name)
+        {
+            var tokens = SyntaxTree.ParseTokens(name).ToArray();
+
+            Assert.Single(tokens);
+
+            var token = tokens[0];
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+            Assert.Equal(name, token.Text);
+        }
+
         public static IEnumerable<object[]> GetTokensData()
         {
             foreach (var t in GetTokens().Concat(GetSeparators()))
@@ -152,6 +168,12 @@ namespace Minsk.Tests.CodeAnalysis.Syntax
                 return true;
 
             if (t1Kind == SyntaxKind.IdentifierToken && t2IsKeyword)
+                return true;
+
+            if (t1Kind == SyntaxKind.IdentifierToken && t2Kind == SyntaxKind.NumberToken)
+                return true;
+
+            if (t1IsKeyword && t2Kind == SyntaxKind.NumberToken)
                 return true;
 
             if (t1Kind == SyntaxKind.NumberToken && t2Kind == SyntaxKind.NumberToken)

--- a/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Minsk/CodeAnalysis/Syntax/Lexer.cs
@@ -182,6 +182,9 @@ namespace Minsk.CodeAnalysis.Syntax
                 case '\r':
                     ReadWhiteSpace();
                     break;
+                case '_':
+                    ReadIdentifierOrKeyword();
+                    break;
                 default:
                     if (char.IsLetter(Current))
                     {
@@ -280,7 +283,7 @@ namespace Minsk.CodeAnalysis.Syntax
 
         private void ReadIdentifierOrKeyword()
         {
-            while (char.IsLetter(Current))
+            while (char.IsLetterOrDigit(Current) || Current == '_')
                 _position++;
 
             var length = _position - _start;


### PR DESCRIPTION
I wanted to create a few functions named `str2`, `str3` etc in order to test my other PR, and I was surprised when the compiler went boom. 😄

This allows digits (except as the first character) and underscores in identifiers.
