### PR TITLE
Re-styled SourceGenerator with CurlyIndenter.

### DIFF
--- a/src/Minsk.Generators/CurlyIndenter.cs
+++ b/src/Minsk.Generators/CurlyIndenter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.CodeDom.Compiler;
+
+namespace Minsk.Generators
+{
+    /// <summary>
+    /// Takes care of opening and closing curly braces for code generation
+    /// </summary>
+    internal class CurlyIndenter : IDisposable
+    {
+        private IndentedTextWriter _indentedTextWriter;
+
+        /// <summary>
+        /// Default constructor that maked a tidies creation of the line before the opening curly
+        /// </summary>
+        /// <param name="indentedTextWriter">The writer to use</param>
+        /// <param name="openingLine">any line to write before the curly</param>
+        public CurlyIndenter(IndentedTextWriter indentedTextWriter, string openingLine = "")
+        {
+            _indentedTextWriter = indentedTextWriter;
+            if (!string.IsNullOrWhiteSpace(openingLine)) 
+                indentedTextWriter.WriteLine(openingLine);
+            indentedTextWriter.WriteLine("{");
+            indentedTextWriter.Indent++;
+        }
+
+        /// <summary>
+        /// When the variable goes out of scope the closing brace is injected and indentation reduced.
+        /// </summary>
+        public void Dispose()
+        {
+            _indentedTextWriter.Indent--;
+            _indentedTextWriter.WriteLine("}");
+        }
+    }
+}


### PR DESCRIPTION
Hi @terrajobst,

This is quite a minor PR.

It comes from a hack I sometimes use when writing files that regularly have `header -> content -> footer` structures.

The hack is to write the header with a disposable class instantiated with a `using` statement so that when the closing brace is hit and it goes out of scope the footer is taken care of automatically.

In the case of the code-generator it's certainly not a big deal, I'm submitting mainly to get your opinion on the approach and style.

Thanks,
Claudio