### PR TITLE
Build both Debug and Release configurations for all major OS during CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ parameters:
     vmImage:  ubuntu-latest
   - name:     Windows
     vmImage:  windows-latest
+  - name:     macOS
+    vmImage:  macOS-latest
 - name:     configurations
   type:     object
   default:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,31 +1,48 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
-pool:
-  vmImage: 'ubuntu-latest'
-
 variables:
-  buildConfiguration: 'Release'
   sln: './src/minsk.sln'
   tests: './src/Minsk.Tests/Minsk.Tests.csproj'
   samples: './samples/samples.sln'
 
-steps:
-- task: DotNetCoreCLI@2
-  displayName: Build minsk ($(buildConfiguration))
-  inputs:
-    command: build
-    projects: $(sln)
-    arguments: -c $(buildConfiguration)
-- task: DotNetCoreCLI@2
-  displayName: Run tests ($(buildConfiguration))
-  inputs:
-    command: test
-    projects: $(tests)
-    arguments: -c $(buildConfiguration)
-    publishTestResults: true
-- task: DotNetCoreCLI@2
-  displayName: Build samples ($(buildConfiguration))
-  inputs:
-    command: build
-    projects: $(samples)
-    arguments: -c $(buildConfiguration)
+parameters:
+- name:     operatingSystems
+  type:     object
+  default:
+  - name:     Ubuntu
+    vmImage:  ubuntu-latest
+  - name:     Windows
+    vmImage:  windows-latest
+- name:     configurations
+  type:     object
+  default:
+  - Debug
+  - Release
+
+jobs:
+- ${{ each c in parameters.configurations }}:
+  - ${{ each os in parameters.operatingSystems }}:
+    - job:  job${{ os.name }}${{ c }}
+      displayName: ${{ c }} (${{ os.name }})
+      pool:
+        vmImage:  ${{ os.vmImage }}
+      steps:
+      - task: DotNetCoreCLI@2
+        displayName: Build minsk (${{ os.name }} ${{ c }})
+        inputs:
+          command: build
+          projects: $(sln)
+          arguments: --configuration ${{ c }}
+      - task: DotNetCoreCLI@2
+        displayName: Run tests (${{ os.name }} ${{ c }})
+        inputs:
+          command: test
+          projects: $(tests)
+          arguments: --configuration ${{ c }}
+          publishTestResults: true
+      - task: DotNetCoreCLI@2
+        displayName: Build samples (${{ os.name }} ${{ c }})
+        inputs:
+          command: build
+          projects: $(samples)
+          arguments: --configuration ${{ c }}


### PR DESCRIPTION
Modified the azure-pipelines template to build both the `Debug` and `Release` configurations for both `Windows` and `Linux` operating systems.

The solution uses a parameterized azure-pipeline template. This means that the OSs and Configurations can be configured in the Web UI when queueing a manual build.

I chose not to use the [`matrix` job strategy](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema#matrix) in the template as the matrix-strategy as it did not allow me the fidelity I wanted when setting Display Names for the jobs. *E.g. note that OS is not a simple string, but an object containing the `vmImage` and a human readable `name`.*

I also found matrix strategies to be harder to reason about, while I suspect most programmers will understand a foreach-loop over a sequence.

**Update** (2020-05-26): added macOS build to the pipeline as well, so that all three major OSes are covered.