### PR TITLE
Call `Optimize` Rather than `OptimizeMacros`

### DIFF
--- a/src/Minsk/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Minsk/CodeAnalysis/Emit/Emitter.cs
@@ -240,7 +240,7 @@ namespace Minsk.CodeAnalysis.Emit
                 instructionToFixup.Operand = targetInstruction;
             }
 
-            method.Body.OptimizeMacros();
+            method.Body.Optimize();
         }
 
         private void EmitStatement(ILProcessor ilProcessor, BoundStatement node)


### PR DESCRIPTION
Mono.Cecil.Rocks contains three main optimisations: Macro-re-write,
Branch-re-write, and immediate integer compaction. The `Optimize` method
runs all of these against the given method body. This means that
immediate values that _can_ be represented with a smaller encoding
will be converted as well as the existing re-writes performed by
`OptimizeMacros`.