### PR TITLE
Enforce nuget package source to work around intermittent CI failures

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Minsk (just as my own personal projects that use Azure DevOps CI) currently suffers from intermittent CI failures where the CI fails to restore packages from nuget. See [here](https://developercommunity.visualstudio.com/comments/1093014/view.html) for a description of the issue.

A workaround for the issue is to enforce usage of Nuget as a package source. This PR adds a standard `nuget.config` file as produced by running `dotnet new nugetconfig`.