### PR TITLE
Add Configuration and OS to published test results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,9 @@ jobs:
       displayName: ${{ c }} (${{ os.name }})
       pool:
         vmImage:  ${{ os.vmImage }}
+      variables:
+        BuildConfiguration: ${{ c }}
+        BuildPlatform:      ${{ os.name }}
       steps:
       - task: DotNetCoreCLI@2
         displayName: Build minsk (${{ os.name }} ${{ c }})
@@ -42,9 +45,6 @@ jobs:
           projects: $(tests)
           arguments: --configuration ${{ c }}
           publishTestResults: true
-        env:
-          BuildConfiguration: ${{ c }}
-          BuildPlatform:      ${{ os.name }}
       - task: DotNetCoreCLI@2
         displayName: Build samples (${{ os.name }} ${{ c }})
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,9 @@ jobs:
           projects: $(tests)
           arguments: --configuration ${{ c }}
           publishTestResults: true
+        env:
+          BuildConfiguration: ${{ c }}
+          BuildPlatform:      ${{ os.name }}
       - task: DotNetCoreCLI@2
         displayName: Build samples (${{ os.name }} ${{ c }})
         inputs:


### PR DESCRIPTION
Accroding to the `publishTestResult` function in the .NET Core CLI task, the published test results can incorporate additional information if the Build Configuration and Platform are specified.

https://github.com/microsoft/azure-pipelines-tasks/blob/541a14e88bf9b24b4efd89b71ff67dd98b60ebb2/Tasks/DotNetCoreCLIV2/dotnetcore.ts#L189-L190 

This additional info is simply nice to have when you inspect the test runs in the Tests pane of a CI build.

![image](https://user-images.githubusercontent.com/8759693/85879265-5846a600-b7da-11ea-8e95-ff27643e8d26.png)
